### PR TITLE
handling kube-DNS UDP discovery with toPorts

### DIFF
--- a/src/networkpolicy/helperFunctions.go
+++ b/src/networkpolicy/helperFunctions.go
@@ -114,6 +114,14 @@ func FilterNetworkLogsByConfig(logs []types.KnoxNetworkLog, pods []types.Pod) []
 			continue
 		}
 
+		if log.Protocol == 17 && log.IsReply && log.DstNamespace == "reserved:world" {
+			/*
+				fmt.Printf("dropping UDP SrcPort:%v DstPort:%v DstNamespace:%v\n",
+					log.SrcPort, log.DstPort, log.DstNamespace)
+			*/
+			continue
+		}
+
 		for _, filter := range NetworkLogFilters {
 			checkItems := getHaveToCheckItems(filter)
 

--- a/src/plugin/cilium.go
+++ b/src/plugin/cilium.go
@@ -205,6 +205,7 @@ func ConvertCiliumFlowToKnoxNetworkLog(ciliumFlow *cilium.Flow) (types.KnoxNetwo
 	} else {
 		log.DstPodName = ciliumFlow.Destination.GetPodName()
 	}
+	log.IsReply = ciliumFlow.GetIsReply().GetValue()
 
 	// get L3
 	if ciliumFlow.IP != nil {

--- a/src/types/logData.go
+++ b/src/types/logData.go
@@ -21,6 +21,7 @@ type KnoxNetworkLog struct {
 	DstPort  int    `json:"dst_port,omitempty" bson:"dst_port"`
 
 	SynFlag bool `json:"syn_flag,omitempty" bson:"syn_flag"` // for tcp
+	IsReply bool `json:"is_reply,omitempty" bson:"is_reply"` // is_reply
 
 	DNSQuery  string   `json:"dns_query,omitempty" bson:"dns_query"`       // for L7 dns
 	DNSRes    string   `json:"dns_response,omitempty" bson:"dns_response"` // for L7 dns


### PR DESCRIPTION
Added a check for handling spurious logs for kube-dns UDP packets.
Check the issue for problem/root-cause/fix-rationale.

Fixes: #329