### PR TITLE
Fixed change in parameters names in cluster-mgmt APIs

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -26,7 +26,7 @@ RUN go build -o knoxAutoPolicy main.go
 ### Make executable image
 
 #FROM debian:latest
-FROM artifactory.accuknox.com/accuknox/ubuntu:21.10
+FROM artifactory.accuknox.com/accuknox/ubuntu:22.04
 
 COPY ./src/conf/local.yaml conf/conf.yaml
 COPY --from=builder /usr/src/knox/knoxAutoPolicy /knoxAutoPolicy

--- a/src/cluster/clusterMgmtHandler.go
+++ b/src/cluster/clusterMgmtHandler.go
@@ -177,8 +177,8 @@ func GetServicesFromCluster(cluster types.Cluster) []types.Service {
 
 	url := "/cm/api/v1/cluster-management/get-service-details"
 	data := map[string]interface{}{
-		"WorkspaceID": cluster.WorkspaceID,
-		"ClusterID":   []int{cluster.ClusterID},
+		"workspace_id": cluster.WorkspaceID,
+		"cluster_id":   []int{cluster.ClusterID},
 	}
 
 	res := getResponseBytes("POST", url, data)
@@ -250,8 +250,8 @@ func GetEndpointsFromCluster(cluster types.Cluster) []types.Endpoint {
 
 	url := "/cm/api/v1/cluster-management/get-endpoints-details"
 	data := map[string]interface{}{
-		"WorkspaceID": cluster.WorkspaceID,
-		"ClusterID":   []int{cluster.ClusterID},
+		"workspace_id": cluster.WorkspaceID,
+		"cluster_id":   []int{cluster.ClusterID},
 	}
 
 	res := getResponseBytes("POST", url, data)
@@ -320,9 +320,9 @@ func GetPodsFromCluster(cluster types.Cluster) []types.Pod {
 
 	url := "/cm/api/v1/cluster-management/pods-in-node"
 	data := map[string]interface{}{
-		"WorkspaceID": cluster.WorkspaceID,
-		"ClusterID":   []int{cluster.ClusterID},
-		"Time":        0,
+		"workspace_id": cluster.WorkspaceID,
+		"cluster_id":   []int{cluster.ClusterID},
+		"Time":         0,
 	}
 
 	res := getResponseBytes("POST", url, data)

--- a/src/types/clusterData.go
+++ b/src/types/clusterData.go
@@ -3,8 +3,8 @@ package types
 // Cluster Structure
 type Cluster struct {
 	ClusterName string `json:"ClusterName" bson:"ClusterName"`
-	ClusterID   int    `json:"ClusterID" bson:"ClusterID"`
-	WorkspaceID int    `json:"WorkspaceID" bson:"WorkspaceID"`
+	ClusterID   int    `json:"cluster_id" bson:"ClusterID"`
+	WorkspaceID int    `json:"workspace_id" bson:"WorkspaceID"`
 	Location    string `json:"Location" bson:"Location"`
 }
 


### PR DESCRIPTION
"WorkspaceID" to "workspace_id" ,"ClusterID" to "cluster_id" ,"NodeID" to "node_id", "PodID" to "pod_id" 

thanks @weirdwiz for the code changes.