### PR TITLE
hubble-relay/cilium restart problem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deployments"]
-	path = deployments
-	url = https://github.com/accuknox/knoxAutoPolicy-deployment

--- a/src/build/build_knoxautopolicy.sh
+++ b/src/build/build_knoxautopolicy.sh
@@ -3,7 +3,7 @@
 AUTOPOL_HOME=`dirname $(realpath "$0")`/../..
 cd $AUTOPOL_HOME
 AUTOPOL_SRC_HOME=$AUTOPOL_HOME/src
-[[ "$REPO" == "" ]] && REPO="accuknox/knoxautopolicy",
+[[ "$REPO" == "" ]] && REPO="accuknox/knoxautopolicy"
 
 # check version
 

--- a/src/build/push_knoxautopolicy.sh
+++ b/src/build/push_knoxautopolicy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 AUTOPOL_HOME=`dirname $(realpath "$0")`/../..
-[[ "$REPO" == "" ]] && REPO="accuknox/knoxautopolicy",
+[[ "$REPO" == "" ]] && REPO="accuknox/knoxautopolicy"
 
 # check version
 VERSION=dev

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -35,8 +35,8 @@ func waitForDB(db *sql.DB) {
 	for {
 		err := db.Ping()
 		if err != nil {
-			log.Error().Msg("Cannot reach the database, Retrying.")
 			time.Sleep(time.Second * 1)
+			log.Error().Msgf("db.Ping() failed. Will retry. err=%s", err.Error())
 		} else {
 			break
 		}
@@ -48,11 +48,13 @@ func connectMySQL(cfg types.ConfigDB) (db *sql.DB) {
 		return MockDB
 	}
 
-	db, err := sql.Open(cfg.DBDriver, cfg.DBUser+":"+cfg.DBPass+"@tcp("+cfg.DBHost+":"+cfg.DBPort+")/"+cfg.DBName)
+	dbconn := cfg.DBUser + ":" + cfg.DBPass + "@tcp(" + cfg.DBHost + ":" + cfg.DBPort + ")/" + cfg.DBName
+	db, err := sql.Open(cfg.DBDriver, dbconn)
 	for err != nil {
-		log.Error().Msg("connection error :" + err.Error())
+		log.Error().Msgf("mysql driver:%s, user:%s, host:%s, port:%s, dbname:%s conn-error:%s",
+			cfg.DBDriver, cfg.DBUser, cfg.DBHost, cfg.DBPort, cfg.DBName, err.Error())
 		time.Sleep(time.Second * 1)
-		db, err = sql.Open(cfg.DBDriver, cfg.DBUser+":"+cfg.DBPass+"@tcp("+cfg.DBHost+":"+cfg.DBPort+")/"+cfg.DBName)
+		db, err = sql.Open(cfg.DBDriver, dbconn)
 	}
 
 	db.SetMaxIdleConns(0)


### PR DESCRIPTION
If the hubble-relay/cilium is restarted then the grpc connection from autopolicy engine is lost. There was no handling to reattempt the connection. This PR adds the support.