### PR TITLE
systempolicy: merge system policies

### DIFF
--- a/src/libs/common.go
+++ b/src/libs/common.go
@@ -432,13 +432,9 @@ func WriteCiliumPolicyToYamlFile(namespace string, policies []types.CiliumNetwor
 	}
 }
 
-func WriteKubeArmorPolicyToYamlFile(fname string, namespace string, policies []types.KubeArmorPolicy) {
+func WriteKubeArmorPolicyToYamlFile(fname string, policies []types.KubeArmorPolicy) {
 	fileName := GetEnv("POLICY_DIR", "./")
-	if namespace != "" {
-		fileName = fileName + fname + "_" + namespace + ".yaml"
-	} else {
-		fileName = fileName + fname + ".yaml"
-	}
+	fileName = fileName + fname + ".yaml"
 
 	if err := os.Remove(fileName); err != nil {
 		if !strings.Contains(err.Error(), NoSuchFileOrDir) {

--- a/src/plugin/kubearmor.go
+++ b/src/plugin/kubearmor.go
@@ -32,6 +32,8 @@ func ConvertKnoxSystemPolicyToKubeArmorPolicy(knoxPolicies []types.KnoxSystemPol
 		}
 
 		kubePolicy.Metadata["namespace"] = policy.Metadata["namespace"]
+		kubePolicy.Metadata["clusterName"] = policy.Metadata["clusterName"]
+		kubePolicy.Metadata["containername"] = policy.Metadata["containername"]
 		kubePolicy.Metadata["name"] = policy.Metadata["name"]
 
 		kubePolicy.Spec = policy.Spec

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -256,6 +256,8 @@ func WriteSystemPoliciesToFile_Ext() {
 	kubeArmorPolicies := plugin.ConvertKnoxSystemPolicyToKubeArmorPolicy(sysPols)
 	for _, pol := range kubeArmorPolicies {
 		fname := "kubearmor_policies_" + pol.Metadata["clusterName"] + "_" + pol.Metadata["namespace"] + "_" + pol.Metadata["containername"] + "_" + libs.RandSeq(8)
+		delete(pol.Metadata, "clusterName")
+		delete(pol.Metadata, "containername")
 		libs.WriteKubeArmorPolicyToYamlFile(fname, []types.KubeArmorPolicy{pol})
 	}
 }
@@ -624,7 +626,7 @@ func updateSysPolicySpec(opType string, policy types.KnoxSystemPolicy, src strin
 				policy.Metadata["fromSource"] = src
 			}
 
-			if len(policy.Spec.File.MatchPaths) == 0 {
+			if len(policy.Spec.Process.MatchPaths) == 0 {
 				policy.Spec.Process.MatchPaths = []types.KnoxMatchPaths{matchPaths}
 			} else {
 				policy.Spec.Process.MatchPaths = append(policy.Spec.Process.MatchPaths, matchPaths)


### PR DESCRIPTION
The requirement was to merge multiple system policies (files, processes,
networks) of a given container-namespace-cluster into a singe
`KubeArmorSecurityPolicy`. This would reduce the number of CRDs that are
required in k8s env, thus reducing memory requirement.

Also, one can use this single policy file as an observability data to
verify what files, process, network connections were made by the
container.

Signed-off-by: Rahul Jadhav <r@accuknox.com>