### PR TITLE
systempolicy: Network rules fixes

### DIFF
--- a/src/analyzer/systemPolicyAnalyzer.go
+++ b/src/analyzer/systemPolicyAnalyzer.go
@@ -99,7 +99,7 @@ func populatePbSysPolicyFromSysPolicy(KnoxSysPolicy types.KnoxSystemPolicy) apb.
 	}
 
 	// Spec -- Match Protocol
-	for _, matchProtocol := range KnoxSysPolicy.Spec.Network {
+	for _, matchProtocol := range KnoxSysPolicy.Spec.Network.MatchProtocols {
 		pbMatchProtocol := apb.KnoxMatchProtocols{}
 		pbMatchProtocol.Protocol = matchProtocol.Protocol
 		for _, fromSrc := range matchProtocol.FromSource {

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -457,8 +457,8 @@ func mergeSysPolicies(pols []types.KnoxSystemPolicy) []types.KnoxSystemPolicy {
 		if len(pol.Spec.Process.MatchDirectories) > 0 {
 			results[i].Spec.Process.MatchDirectories = append(results[i].Spec.Process.MatchDirectories, pol.Spec.Process.MatchDirectories...)
 		}
-		if len(pol.Spec.Network) > 0 {
-			results[i].Spec.Network = append(results[i].Spec.Network, pol.Spec.Network...)
+		if len(pol.Spec.Network.MatchProtocols) > 0 {
+			results[i].Spec.Network.MatchProtocols = append(results[i].Spec.Network.MatchProtocols, pol.Spec.Network.MatchProtocols...)
 		}
 	}
 	log.Info().Msgf("Merged %d sys policies into %d policies", len(pols), len(results))
@@ -543,7 +543,7 @@ func updateSysPolicySpec(opType string, policy types.KnoxSystemPolicy, src strin
 			},
 		}
 		policy.Metadata["fromSource"] = src
-		policy.Spec.Network = append(policy.Spec.Network, matchProtocols)
+		policy.Spec.Network.MatchProtocols = append(policy.Spec.Network.MatchProtocols, matchProtocols)
 		return policy
 	}
 	// matchDirectories
@@ -568,11 +568,7 @@ func updateSysPolicySpec(opType string, policy types.KnoxSystemPolicy, src strin
 				policy.Metadata["fromSource"] = src
 			}
 
-			if len(policy.Spec.File.MatchDirectories) == 0 {
-				policy.Spec.File.MatchDirectories = []types.KnoxMatchDirectories{matchDirs}
-			} else {
-				policy.Spec.File.MatchDirectories = append(policy.Spec.File.MatchDirectories, matchDirs)
-			}
+			policy.Spec.File.MatchDirectories = append(policy.Spec.File.MatchDirectories, matchDirs)
 		} else if opType == SYS_OP_PROCESS {
 			if ProcessFromSource {
 				if src != "" {
@@ -585,11 +581,7 @@ func updateSysPolicySpec(opType string, policy types.KnoxSystemPolicy, src strin
 				policy.Metadata["fromSource"] = src
 			}
 
-			if len(policy.Spec.File.MatchDirectories) == 0 {
-				policy.Spec.Process.MatchDirectories = []types.KnoxMatchDirectories{matchDirs}
-			} else {
-				policy.Spec.Process.MatchDirectories = append(policy.Spec.Process.MatchDirectories, matchDirs)
-			}
+			policy.Spec.Process.MatchDirectories = append(policy.Spec.Process.MatchDirectories, matchDirs)
 		}
 	} else {
 		// matchPaths
@@ -609,11 +601,7 @@ func updateSysPolicySpec(opType string, policy types.KnoxSystemPolicy, src strin
 				policy.Metadata["fromSource"] = src
 			}
 
-			if len(policy.Spec.File.MatchPaths) == 0 {
-				policy.Spec.File.MatchPaths = []types.KnoxMatchPaths{matchPaths}
-			} else {
-				policy.Spec.File.MatchPaths = append(policy.Spec.File.MatchPaths, matchPaths)
-			}
+			policy.Spec.File.MatchPaths = append(policy.Spec.File.MatchPaths, matchPaths)
 		} else if opType == SYS_OP_PROCESS {
 			if ProcessFromSource {
 				if src != "" {
@@ -626,11 +614,7 @@ func updateSysPolicySpec(opType string, policy types.KnoxSystemPolicy, src strin
 				policy.Metadata["fromSource"] = src
 			}
 
-			if len(policy.Spec.Process.MatchPaths) == 0 {
-				policy.Spec.Process.MatchPaths = []types.KnoxMatchPaths{matchPaths}
-			} else {
-				policy.Spec.Process.MatchPaths = append(policy.Spec.Process.MatchPaths, matchPaths)
-			}
+			policy.Spec.Process.MatchPaths = append(policy.Spec.Process.MatchPaths, matchPaths)
 		}
 	}
 
@@ -833,7 +817,8 @@ func getProtocolType(str string) string {
 	}
 
 	if reicmp.MatchString(str) {
-		return "icmp,icmp6"
+		return "icmp"
+		// return "icmp,icmp6"
 	}
 	if retcp.MatchString(str) {
 		return "tcp"

--- a/src/systempolicy/systemPolicy_test.go
+++ b/src/systempolicy/systemPolicy_test.go
@@ -30,7 +30,7 @@ func TestRegexp(t *testing.T) {
 		},
 		{
 			res: "domain=AF_INET6 type=SOCK_RAW protocol=58", // icmp6
-			exp: "icmp,icmp6",
+			exp: "icmp",
 		},
 		{
 			res: "domain=AF_NETLINK type=SOCK_RAW protocol=0",
@@ -38,7 +38,7 @@ func TestRegexp(t *testing.T) {
 		},
 		{
 			res: "domain=AF_INET type=SOCK_DGRAM protocol=1",
-			exp: "icmp,icmp6",
+			exp: "icmp",
 		},
 		{
 			res: "domain=AF_INET type=SOCK_DGRAM protocol=17",
@@ -54,7 +54,7 @@ func TestRegexp(t *testing.T) {
 		},
 		{
 			res: "domain=AF_INET6 type=SOCK_DGRAM protocol=58",
-			exp: "icmp,icmp6",
+			exp: "icmp",
 		},
 	}
 
@@ -66,8 +66,8 @@ func TestRegexp(t *testing.T) {
 }
 
 func TestRemoveDuplicates(t *testing.T) {
-	out := removeDuplicates([]string{"tcp", "udp", "icmp", "icmp6", "tcp"})
-	assert.Equal(t, []string{"icmp", "icmp6", "tcp", "udp"}, out)
+	out := removeDuplicates([]string{"tcp", "udp", "icmp", "tcp"})
+	assert.Equal(t, []string{"icmp", "tcp", "udp"}, out)
 
 	out = removeDuplicates([]string{"raw", "tcp", "tcp", "udp", "udp", "udp", "udp", "raw"})
 	assert.Equal(t, []string{"raw", "tcp", "udp"}, out)

--- a/src/types/policyData.go
+++ b/src/types/policyData.go
@@ -203,6 +203,11 @@ type KnoxSys struct {
 	MatchDirectories []KnoxMatchDirectories `json:"matchDirectories,omitempty" yaml:"matchDirectories,omitempty"`
 }
 
+// NetworkRule Structure
+type NetworkRule struct {
+	MatchProtocols []KnoxMatchProtocols `json:"matchProtocols,omitempty" yaml:"matchProtocols,omitempty"`
+}
+
 // KnoxSystemSpec Structure
 type KnoxSystemSpec struct {
 	Severity int      `json:"severity,omitempty" yaml:"severity,omitempty"`
@@ -211,9 +216,9 @@ type KnoxSystemSpec struct {
 
 	Selector Selector `json:"selector,omitempty" yaml:"selector,omitempty"`
 
-	Process KnoxSys              `json:"process,omitempty" yaml:"process,omitempty"`
-	File    KnoxSys              `json:"file,omitempty" yaml:"file,omitempty"`
-	Network []KnoxMatchProtocols `json:"network,omitempty" yaml:"network,omitempty"`
+	Process KnoxSys     `json:"process,omitempty" yaml:"process,omitempty"`
+	File    KnoxSys     `json:"file,omitempty" yaml:"file,omitempty"`
+	Network NetworkRule `json:"network,omitempty" yaml:"network,omitempty"`
 
 	Action string `json:"action,omitempty" yaml:"action,omitempty"`
 }


### PR DESCRIPTION
* icmp rule handling fixed
* rule spec was not matching the kubearmor rule spec for network rules.
  This was fixed.

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>