### PR TITLE
added md5sum based on labels

### DIFF
--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -639,7 +639,8 @@ func mergeSysPolicies(pols []types.KnoxSystemPolicy) []types.KnoxSystemPolicy {
 			mp := &results[i].Spec.Network.MatchProtocols
 			*mp = append(*mp, pol.Spec.Network.MatchProtocols...)
 		}
-		results[i].Metadata["name"] = "autopol-" + pol.Metadata["namespace"] + "-" + pol.Metadata["containername"]
+		md5SumB := []byte(pol.Metadata["labels"])
+		results[i].Metadata["name"] = "autopol-" + pol.Metadata["namespace"] + "-" + pol.Metadata["containername"] + string(md5SumB[:])
 	}
 
 	results = mergeFromSource(results)


### PR DESCRIPTION
The problem was that the policies pushed into `system_policy` were not on per workload basis. GKE microservice demo uses the same containername across all the pods and thus the same policy was overwritten.

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>