### PR TITLE
reformatted policy name

### DIFF
--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -1,17 +1,15 @@
 package systempolicy
 
 import (
-	// md5 is used only for hash creation and the hash is not used as salt for any crypto ops
-	// #nosec G501
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"hash/fnv"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -614,14 +612,16 @@ func mergeFromSource(pols []types.KnoxSystemPolicy) []types.KnoxSystemPolicy {
 	return results
 }
 
+func hashInt(s string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum32()
+}
+
 func mergeSysPolicies(pols []types.KnoxSystemPolicy) []types.KnoxSystemPolicy {
 	var results []types.KnoxSystemPolicy
 	for _, pol := range pols {
-		// We are using md5 digest just for random creation based on label
-		// strings. This hash is not used in any cryptographic operation.
-		// #nosec G401
-		hash := md5.Sum([]byte(pol.Metadata["labels"]))
-		pol.Metadata["name"] = "autopol-" + pol.Metadata["namespace"] + "-" + pol.Metadata["containername"] + "-" + hex.EncodeToString(hash[:])
+		pol.Metadata["name"] = "autopol-system-" + strconv.FormatUint(uint64(hashInt(pol.Metadata["labels"])), 10)
 		i := checkIfMetadataMatches(pol, results)
 		if i < 0 {
 			results = append(results, pol)


### PR DESCRIPTION
The autogenerated policy name is appearing too congested on the SaaS UI. Hence the change.

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>