### PR TITLE
systempolicy: fixes for process handling

### DIFF
--- a/src/feedconsumer/consumer.go
+++ b/src/feedconsumer/consumer.go
@@ -285,7 +285,10 @@ func (cfc *KnoxFeedConsumer) processSystemLogMessage(message []byte) error {
 					Result:        syslog.Result,
 				}
 
-				knoxLog := plugin.ConvertKubeArmorLogToKnoxSystemLog(&log)
+				knoxLog, err := plugin.ConvertKubeArmorLogToKnoxSystemLog(&log)
+				if err != nil {
+					continue
+				}
 				knoxLog.ClusterName = syslog.Clustername
 				plugin.KubeArmorKafkaLogsMutex.Lock()
 				plugin.KubeArmorKafkaLogs = append(plugin.KubeArmorKafkaLogs, &knoxLog)

--- a/src/plugin/kubearmor.go
+++ b/src/plugin/kubearmor.go
@@ -3,7 +3,9 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -107,12 +109,17 @@ func ConvertKubeArmorSystemLogsToKnoxSystemLogs(dbDriver string, docs []map[stri
 	return []types.KnoxSystemLog{}
 }
 
-func ConvertKubeArmorLogToKnoxSystemLog(relayLog *pb.Log) types.KnoxSystemLog {
+func ConvertKubeArmorLogToKnoxSystemLog(relayLog *pb.Log) (types.KnoxSystemLog, error) {
 
 	sources := strings.Split(relayLog.Source, " ")
 	source := ""
 	if len(sources) >= 1 {
 		source = sources[0]
+	}
+
+	// check if source is absolute path and does not terminate in "/"
+	if !filepath.IsAbs(source) || strings.HasSuffix(source, "/") {
+		return types.KnoxSystemLog{}, errors.New("invalid file source")
 	}
 
 	resources := strings.Split(relayLog.Resource, " ")
@@ -121,9 +128,22 @@ func ConvertKubeArmorLogToKnoxSystemLog(relayLog *pb.Log) types.KnoxSystemLog {
 		resource = resources[0]
 	}
 
+	// check if resource is absolute path. "/" is ok.
+	if (relayLog.Operation == "File" || relayLog.Operation == "Process") && !filepath.IsAbs(resource) {
+		return types.KnoxSystemLog{}, errors.New("invalid file resource")
+	}
+
 	readOnly := false
 	if relayLog.Data != "" && strings.Contains(relayLog.Data, "O_RDONLY") {
 		readOnly = true
+	}
+
+	if strings.Contains(source, "runc") {
+		source = ""
+	}
+
+	if strings.Contains(resource, "runc") {
+		resource = ""
 	}
 
 	knoxSystemLog := types.KnoxSystemLog{
@@ -142,7 +162,7 @@ func ConvertKubeArmorLogToKnoxSystemLog(relayLog *pb.Log) types.KnoxSystemLog {
 		Result:         relayLog.Result,
 	}
 
-	return knoxSystemLog
+	return knoxSystemLog, nil
 }
 
 // ========================= //

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -222,8 +222,10 @@ func getSystemLogs() []types.KnoxSystemLog {
 
 		// convert kubearmor relay logs -> knox system logs
 		for _, relayLog := range relayLogs {
-			log := plugin.ConvertKubeArmorLogToKnoxSystemLog(relayLog)
-			systemLogs = append(systemLogs, log)
+			log, err := plugin.ConvertKubeArmorLogToKnoxSystemLog(relayLog)
+			if err == nil {
+				systemLogs = append(systemLogs, log)
+			}
 		}
 	} else if SystemLogFrom == "kafka" {
 		log.Info().Msg("Get system log from kafka consumer")
@@ -918,7 +920,6 @@ func InitSysPolicyDiscoveryConfiguration() {
 
 func PopulateSystemPoliciesFromSystemLogs(sysLogs []types.KnoxSystemLog) []types.KnoxSystemPolicy {
 
-	isWpfsDbUpdated := false
 	discoveredSystemPolicies := []types.KnoxSystemPolicy{}
 
 	// delete duplicate logs
@@ -952,6 +953,7 @@ func PopulateSystemPoliciesFromSystemLogs(sysLogs []types.KnoxSystemLog) []types
 			}
 
 			polCnt := 0
+			isWpfsDbUpdated := false
 			// 1. discover file operation system policy
 			if SystemPolicyTypes&SYS_OP_FILE_INT > 0 {
 				fileOpLogs := getOperationLogs(SYS_OP_FILE, perPodlogs)


### PR DESCRIPTION
With the [parent]processName fixes in kubearmor the
auto-policy-discovery is now working fine i.e. generating process names
with proper absolute system paths.

Signed-off-by: Rahul Jadhav <r@accuknox.com>