### PR TITLE
Deduplication

### DIFF
--- a/src/analyzer/networkPolicyAnalyzer.go
+++ b/src/analyzer/networkPolicyAnalyzer.go
@@ -135,11 +135,13 @@ func populatePbNetPolicyFromNetPolicy(KnoxNwPolicy types.KnoxNetworkPolicy) apb.
 func extractNetworkPoliciesFromNetworkLogs(networkLogs []types.KnoxNetworkLog) []*apb.KnoxNetworkPolicy {
 
 	pbNetPolicies := []*apb.KnoxNetworkPolicy{}
-	netPolicies := netpolicy.PopulateNetworkPoliciesFromNetworkLogs(networkLogs)
+	netPoliciesPerNamespace := netpolicy.PopulateNetworkPoliciesFromNetworkLogs(networkLogs)
 
-	for _, netPolicy := range netPolicies {
-		pbNetPolicy := populatePbNetPolicyFromNetPolicy(netPolicy)
-		pbNetPolicies = append(pbNetPolicies, &pbNetPolicy)
+	for _, netPolicies := range netPoliciesPerNamespace {
+		for _, netPolicy := range netPolicies {
+			pbNetPolicy := populatePbNetPolicyFromNetPolicy(netPolicy)
+			pbNetPolicies = append(pbNetPolicies, &pbNetPolicy)
+		}
 	}
 
 	return pbNetPolicies

--- a/src/analyzer/networkPolicyAnalyzer.go
+++ b/src/analyzer/networkPolicyAnalyzer.go
@@ -52,7 +52,7 @@ func populatePbNetPolicyFromNetPolicy(KnoxNwPolicy types.KnoxNetworkPolicy) apb.
 			pbToCIDRs = append(pbToCIDRs, &pbToCIDR)
 		}
 
-		pbEgress.ToEndtities = append(pbEgress.ToEndtities, egress.ToEndtities...)
+		pbEgress.ToEndtities = append(pbEgress.ToEndtities, egress.ToEntities...)
 
 		for _, toService := range egress.ToServices {
 			pbToService := apb.SpecService{}

--- a/src/networkpolicy/deduplicator.go
+++ b/src/networkpolicy/deduplicator.go
@@ -557,7 +557,7 @@ func UpdateEntity(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.Kn
 
 	newEntities := []string{}
 	if newPolicy.Metadata["type"] == PolicyTypeEgress {
-		newEntities = newPolicy.Spec.Egress[0].ToEndtities
+		newEntities = newPolicy.Spec.Egress[0].ToEntities
 	} else {
 		newEntities = newPolicy.Spec.Ingress[0].FromEntities
 	}
@@ -567,7 +567,7 @@ func UpdateEntity(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.Kn
 	for _, latestPolicy := range latestPolicies {
 		existEntities := []string{}
 		if newPolicy.Metadata["type"] == PolicyTypeEgress {
-			existEntities = latestPolicy.Spec.Egress[0].ToEndtities
+			existEntities = latestPolicy.Spec.Egress[0].ToEntities
 		} else {
 			existEntities = latestPolicy.Spec.Ingress[0].FromEntities
 		}
@@ -605,7 +605,7 @@ func UpdateEntity(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.Kn
 	// at least one updated
 	if updated {
 		if newPolicy.Metadata["type"] == PolicyTypeEgress {
-			newPolicy.Spec.Egress[0].ToEndtities = newEntities
+			newPolicy.Spec.Egress[0].ToEntities = newEntities
 		} else {
 			newPolicy.Spec.Ingress[0].FromEntities = newEntities
 		}

--- a/src/networkpolicy/deduplicator.go
+++ b/src/networkpolicy/deduplicator.go
@@ -282,7 +282,7 @@ func UpdateHTTP(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.Knox
 	}
 
 	newHTTP := []types.SpecHTTP{}
-	if newPolicy.Metadata["type"] == "egress" {
+	if newPolicy.Metadata["type"] == PolicyTypeEgress {
 		newHTTP = newPolicy.Spec.Egress[0].ToHTTPs
 	} else {
 		newHTTP = newPolicy.Spec.Ingress[0].ToHTTPs
@@ -292,7 +292,7 @@ func UpdateHTTP(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.Knox
 
 	for _, latestPolicy := range latestPolicies {
 		existHTTP := []types.SpecHTTP{}
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			existHTTP = latestPolicy.Spec.Egress[0].ToHTTPs
 		} else {
 			existHTTP = latestPolicy.Spec.Ingress[0].ToHTTPs
@@ -330,7 +330,7 @@ func UpdateHTTP(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.Knox
 
 	// at least one updated
 	if updated {
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			newPolicy.Spec.Egress[0].ToHTTPs = newHTTP
 		} else {
 			newPolicy.Spec.Ingress[0].ToHTTPs = newHTTP
@@ -359,7 +359,7 @@ func UpdateToPorts(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.K
 
 	newToPorts := []types.SpecPort{}
 	newICMPs := []types.SpecICMP{}
-	if newPolicy.Metadata["type"] == "egress" {
+	if newPolicy.Metadata["type"] == PolicyTypeEgress {
 		newToPorts = newPolicy.Spec.Egress[0].ToPorts
 		newICMPs = newPolicy.Spec.Egress[0].ICMPs
 	} else {
@@ -372,7 +372,7 @@ func UpdateToPorts(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.K
 	for _, latestPolicy := range latestPolicies {
 		existToPorts := []types.SpecPort{}
 		existICMPs := []types.SpecICMP{}
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			existToPorts = latestPolicy.Spec.Egress[0].ToPorts
 			existICMPs = latestPolicy.Spec.Egress[0].ICMPs
 		} else {
@@ -431,7 +431,7 @@ func UpdateToPorts(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.K
 
 	// at least one updated
 	if updated {
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			newPolicy.Spec.Egress[0].ToPorts = newToPorts
 			newPolicy.Spec.Egress[0].ICMPs = newICMPs
 		} else {
@@ -454,7 +454,7 @@ func UpdateMatchLabels(newPolicy types.KnoxNetworkPolicy, existingPolicies []typ
 	newICMPs := []types.SpecICMP{}
 	newToPorts := []types.SpecPort{}
 	newTargetLabelsCount := 0
-	if newPolicy.Metadata["type"] == "egress" {
+	if newPolicy.Metadata["type"] == PolicyTypeEgress {
 		newToPorts = newPolicy.Spec.Egress[0].ToPorts
 		newICMPs = newPolicy.Spec.Egress[0].ICMPs
 		newTargetLabelsCount = len(newPolicy.Spec.Egress[0].MatchLabels)
@@ -471,7 +471,7 @@ func UpdateMatchLabels(newPolicy types.KnoxNetworkPolicy, existingPolicies []typ
 		existICMPs := []types.SpecICMP{}
 		existTargetLabelsCount := 0
 
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			existToPorts = latestPolicy.Spec.Egress[0].ToPorts
 			existICMPs = latestPolicy.Spec.Egress[0].ICMPs
 			existTargetLabelsCount = len(latestPolicy.Spec.Egress[0].MatchLabels)
@@ -534,7 +534,7 @@ func UpdateMatchLabels(newPolicy types.KnoxNetworkPolicy, existingPolicies []typ
 
 	// at least one updated occurred
 	if updated {
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			newPolicy.Spec.Egress[0].ToPorts = newToPorts
 			newPolicy.Spec.Egress[0].ICMPs = newICMPs
 		} else {
@@ -556,7 +556,7 @@ func UpdateEntity(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.Kn
 	}
 
 	newEntities := []string{}
-	if newPolicy.Metadata["type"] == "egress" {
+	if newPolicy.Metadata["type"] == PolicyTypeEgress {
 		newEntities = newPolicy.Spec.Egress[0].ToEndtities
 	} else {
 		newEntities = newPolicy.Spec.Ingress[0].FromEntities
@@ -566,7 +566,7 @@ func UpdateEntity(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.Kn
 
 	for _, latestPolicy := range latestPolicies {
 		existEntities := []string{}
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			existEntities = latestPolicy.Spec.Egress[0].ToEndtities
 		} else {
 			existEntities = latestPolicy.Spec.Ingress[0].FromEntities
@@ -604,7 +604,7 @@ func UpdateEntity(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.Kn
 
 	// at least one updated
 	if updated {
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			newPolicy.Spec.Egress[0].ToEndtities = newEntities
 		} else {
 			newPolicy.Spec.Ingress[0].FromEntities = newEntities
@@ -624,7 +624,7 @@ func UpdateService(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.K
 	}
 
 	newServices := []types.SpecService{}
-	if newPolicy.Metadata["type"] == "egress" {
+	if newPolicy.Metadata["type"] == PolicyTypeEgress {
 		newServices = newPolicy.Spec.Egress[0].ToServices
 	} else {
 		return newPolicy, true
@@ -634,7 +634,7 @@ func UpdateService(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.K
 
 	for _, latestPolicy := range latestPolicies {
 		existServices := []types.SpecService{}
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			existServices = latestPolicy.Spec.Egress[0].ToServices
 		} else {
 			continue
@@ -672,7 +672,7 @@ func UpdateService(newPolicy types.KnoxNetworkPolicy, existingPolicies []types.K
 
 	// at least one updated
 	if updated {
-		if newPolicy.Metadata["type"] == "egress" {
+		if newPolicy.Metadata["type"] == PolicyTypeEgress {
 			newPolicy.Spec.Egress[0].ToServices = newServices
 		}
 
@@ -893,7 +893,7 @@ func UpdateDuplicatedPolicy(existingPolicies []types.KnoxNetworkPolicy, discover
 		}
 
 		// step 5: update existing FQDN+toPorts rules: egress
-		if strings.Contains(policy.Metadata["rule"], "toFQDNs") && policy.Metadata["type"] == "egress" {
+		if strings.Contains(policy.Metadata["rule"], "toFQDNs") && policy.Metadata["type"] == PolicyTypeEgress {
 			updatedPolicy, updated := UpdateToPorts(namedPolicy, existingPolicies)
 			if updated {
 				namedPolicy = updatedPolicy
@@ -909,7 +909,7 @@ func UpdateDuplicatedPolicy(existingPolicies []types.KnoxNetworkPolicy, discover
 		}
 
 		// step 7: update existing Entities rules: egress
-		if strings.Contains(policy.Metadata["rule"], "toServices") && policy.Metadata["type"] == "egress" {
+		if strings.Contains(policy.Metadata["rule"], "toServices") && policy.Metadata["type"] == PolicyTypeEgress {
 			updatedPolicy, updated := UpdateService(namedPolicy, existingPolicies)
 			if updated {
 				namedPolicy = updatedPolicy

--- a/src/networkpolicy/deduplicator_test.go
+++ b/src/networkpolicy/deduplicator_test.go
@@ -184,7 +184,7 @@ func TestGetLatestEntityPolicy(t *testing.T) {
 
 			Egress: []types.Egress{
 				types.Egress{
-					ToEndtities: []string{"testEntity"},
+					ToEntities: []string{"testEntity"},
 				},
 			},
 		},
@@ -429,7 +429,7 @@ func TestUpdateEntity(t *testing.T) {
 
 			Egress: []types.Egress{
 				types.Egress{
-					ToEndtities: []string{"testEntity"},
+					ToEntities: []string{"testEntity"},
 				},
 			},
 		},
@@ -437,11 +437,11 @@ func TestUpdateEntity(t *testing.T) {
 
 	newPolicy := types.KnoxNetworkPolicy{}
 	libs.DeepCopy(&newPolicy, &existPolicy)
-	newPolicy.Spec.Egress[0].ToEndtities[0] = "newEntity"
+	newPolicy.Spec.Egress[0].ToEntities[0] = "newEntity"
 
 	expected := types.KnoxNetworkPolicy{}
 	libs.DeepCopy(&expected, &newPolicy)
-	expected.Spec.Egress[0].ToEndtities = append(expected.Spec.Egress[0].ToEndtities, "testEntity")
+	expected.Spec.Egress[0].ToEntities = append(expected.Spec.Egress[0].ToEntities, "testEntity")
 
 	existings := []types.KnoxNetworkPolicy{existPolicy}
 

--- a/src/networkpolicy/networkPolicy.go
+++ b/src/networkpolicy/networkPolicy.go
@@ -1445,7 +1445,7 @@ func buildNetworkPolicy(namespace string, services []types.Service, aggregatedSr
 				sort.Strings(dst.Additionals)
 
 				// handle for entity policy in Cilium
-				egressRule.ToEndtities = dst.Additionals
+				egressRule.ToEntities = dst.Additionals
 
 				// check toPorts rule
 				if len(dst.ToPorts) > 0 && discoverRuleTypes&TO_PORTS > 0 {

--- a/src/networkpolicy/networkPolicy.go
+++ b/src/networkpolicy/networkPolicy.go
@@ -1164,7 +1164,7 @@ func buildIngressFromEntitiesPolicy(namespace string, mergedSrcPerMergedDst map[
 			}
 
 			for _, dst := range aggregatedMergedDsts {
-				if dst.MatchLabels == "" || dst.Namespace == "kube-system" {
+				if dst.MatchLabels == "" {
 					continue
 				}
 
@@ -1362,7 +1362,7 @@ func buildNetworkPolicy(namespace string, services []types.Service, aggregatedSr
 				}
 
 				// check ingress
-				if discoverPolicyTypes&INGRESS > 0 && dst.Namespace != "kube-system" {
+				if discoverPolicyTypes&INGRESS > 0 {
 					ingressPolicy := buildNewIngressPolicyFromEgressPolicy(egressRule, egressPolicy.Spec.Selector)
 					ingressPolicy.Spec.Ingress[0].MatchLabels["k8s:io.kubernetes.pod.namespace"] = namespace
 					ingressPolicy.FlowIDs = egressPolicy.FlowIDs

--- a/src/networkpolicy/networkPolicy.go
+++ b/src/networkpolicy/networkPolicy.go
@@ -62,6 +62,11 @@ const (
 	FROM_ENTITIES = 1 << 9 // 512
 )
 
+const (
+	PolicyTypeIngress = "ingress"
+	PolicyTypeEgress  = "egress"
+)
+
 // if the target IP is in out-of-cluster
 var ReservedWorld = "reserved:world"
 
@@ -1082,7 +1087,7 @@ func buildNewKnoxPolicy() types.KnoxNetworkPolicy {
 
 func buildNewKnoxEgressPolicy() types.KnoxNetworkPolicy {
 	policy := buildNewKnoxPolicy()
-	policy.Metadata["type"] = "egress"
+	policy.Metadata["type"] = PolicyTypeEgress
 	policy.Spec.Egress = []types.Egress{}
 
 	return policy
@@ -1090,7 +1095,7 @@ func buildNewKnoxEgressPolicy() types.KnoxNetworkPolicy {
 
 func buildNewKnoxIngressPolicy() types.KnoxNetworkPolicy {
 	policy := buildNewKnoxPolicy()
-	policy.Metadata["type"] = "ingress"
+	policy.Metadata["type"] = PolicyTypeIngress
 	policy.Spec.Ingress = []types.Ingress{}
 
 	return policy

--- a/src/plugin/cilium.go
+++ b/src/plugin/cilium.go
@@ -467,11 +467,11 @@ func ConvertKnoxNetworkPolicyToCiliumPolicy(services []types.Service, inPolicy t
 					cidrs = append(cidrs, toCIDR.CIDRs...)
 					ciliumEgress.ToCIDRs = cidrs
 				}
-			} else if len(knoxEgress.ToEndtities) > 0 {
+			} else if len(knoxEgress.ToEntities) > 0 {
 				// ================= //
 				// build Entity rule //
 				// ================= //
-				for _, entity := range knoxEgress.ToEndtities {
+				for _, entity := range knoxEgress.ToEntities {
 					if ciliumEgress.ToEntities == nil {
 						ciliumEgress.ToEntities = []string{}
 					}

--- a/src/types/policyData.go
+++ b/src/types/policyData.go
@@ -62,11 +62,11 @@ type Egress struct {
 	ICMPs       []SpecICMP        `json:"icmps,omitempty" yaml:"icmps,omitempty" bson:"icmps,omitempty"`
 	ToPorts     []SpecPort        `json:"toPorts,omitempty" yaml:"toPorts,omitempty" bson:"toPorts,omitempty"`
 
-	ToCIDRs     []SpecCIDR    `json:"toCIDRs,omitempty" yaml:"toCIDRs,omitempty" bson:"toCIDRs,omitempty"`
-	ToEndtities []string      `json:"toEntities,omitempty" yaml:"toEntities,omitempty" bson:"toEntities,omitempty"`
-	ToServices  []SpecService `json:"toServices,omitempty" yaml:"toServices,omitempty" bson:"toServices,omitempty"`
-	ToFQDNs     []SpecFQDN    `json:"toFQDNs,omitempty" yaml:"toFQDNs,omitempty" bson:"toFQDNs,omitempty"`
-	ToHTTPs     []SpecHTTP    `json:"toHTTPs,omitempty" yaml:"toHTTPs,omitempty" bson:"toHTTPs,omitempty"`
+	ToCIDRs    []SpecCIDR    `json:"toCIDRs,omitempty" yaml:"toCIDRs,omitempty" bson:"toCIDRs,omitempty"`
+	ToEntities []string      `json:"toEntities,omitempty" yaml:"toEntities,omitempty" bson:"toEntities,omitempty"`
+	ToServices []SpecService `json:"toServices,omitempty" yaml:"toServices,omitempty" bson:"toServices,omitempty"`
+	ToFQDNs    []SpecFQDN    `json:"toFQDNs,omitempty" yaml:"toFQDNs,omitempty" bson:"toFQDNs,omitempty"`
+	ToHTTPs    []SpecHTTP    `json:"toHTTPs,omitempty" yaml:"toHTTPs,omitempty" bson:"toHTTPs,omitempty"`
 }
 
 // Spec Structure


### PR DESCRIPTION
- Fix to generate ingress policies for pods in `kube-system` namespace.
- Fix for doing policy deduplication properly when the network flow involves two different namespaces (#449)
- Fixed policy duplication when policies are based on `from/toEntities`