### PR TITLE
Refactored code to aggregate network policy per deployment/endpoint

### DIFF
--- a/src/libs/dbHandler.go
+++ b/src/libs/dbHandler.go
@@ -87,6 +87,18 @@ func UpdateOutdatedNetworkPolicy(cfg types.ConfigDB, outdatedPolicy string, late
 	}
 }
 
+func UpdateNetworkPolicy(cfg types.ConfigDB, policy types.KnoxNetworkPolicy) {
+	if cfg.DBDriver == "mysql" {
+		if err := UpdateNetworkPolicyToMySQL(cfg, policy); err != nil {
+			log.Error().Msg(err.Error())
+		}
+	} else if cfg.DBDriver == "sqlite3" {
+		if err := UpdateNetworkPolicyToSQLite(cfg, policy); err != nil {
+			log.Error().Msg(err.Error())
+		}
+	}
+}
+
 func InsertNetworkPolicies(cfg types.ConfigDB, policies []types.KnoxNetworkPolicy) {
 	if cfg.DBDriver == "mysql" {
 		if err := InsertNetworkPoliciesToMySQL(cfg, policies); err != nil {

--- a/src/libs/dbHandler_test.go
+++ b/src/libs/dbHandler_test.go
@@ -41,9 +41,10 @@ func TestGetNetworkPolicies(t *testing.T) {
 		"status",        // str
 		"outdated",      // str
 		"spec",          // []byte
-		"generatedTime", // int
+		"generatedTime", // uint64
+		"updatedTime",   // uint64
 	}).
-		AddRow("", "test", flowID, "", "", "", "", "", "", "", spec, 0)
+		AddRow("", "test", flowID, "", "", "", "", "", "", "", spec, 0, 0)
 
 	mock.ExpectQuery("^SELECT (.+) FROM network_policy*").
 		WillReturnRows(rows)
@@ -71,18 +72,19 @@ func TestInsertNetworkPolicies(t *testing.T) {
 	prep := mock.ExpectPrepare("INSERT INTO network_policy")
 	prep.ExpectExec().
 		WithArgs(
-			"",     // str
-			"kind", // str
-			flowID, // []byte
-			"",     // str
-			"",     // str
-			"",     // str
-			"",     // str
-			"",     // str
-			"",     // str
-			"",     // str
-			spec,   // []byte
-			0,      // int
+			"",               // str
+			"kind",           // str
+			flowID,           // []byte
+			"",               // str
+			"",               // str
+			"",               // str
+			"",               // str
+			"",               // str
+			"",               // str
+			"",               // str
+			spec,             // []byte
+			sqlmock.AnyArg(), // uint64
+			sqlmock.AnyArg(), // uint64
 		).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	nfe := []types.KnoxNetworkPolicy{
@@ -100,44 +102,45 @@ func TestInsertNetworkPolicies(t *testing.T) {
 }
 
 func TestInsertNetworkPoliciesSQLite(t *testing.T) {
-        // prepare mock sqlite
-        _, mock := NewMock()
+	// prepare mock sqlite
+	_, mock := NewMock()
 
-        policy := types.KnoxNetworkPolicy{}
+	policy := types.KnoxNetworkPolicy{}
 
-        specPtr := &policy.Spec
-        spec, _ := json.Marshal(specPtr)
+	specPtr := &policy.Spec
+	spec, _ := json.Marshal(specPtr)
 
-        flowIDsPrt := &policy.FlowIDs
-        flowID, _ := json.Marshal(flowIDsPrt)
+	flowIDsPrt := &policy.FlowIDs
+	flowID, _ := json.Marshal(flowIDsPrt)
 
-        prep := mock.ExpectPrepare("INSERT INTO network_policy")
-        prep.ExpectExec().
-                WithArgs(
-                        "",     // str
-                        "kind", // str
-                        flowID, // []byte
-                        "",     // str
-                        "",     // str
-                        "",     // str
-                        "",     // str
-                        "",     // str
-                        "",     // str
-                        "",     // str
-                        spec,   // []byte
-                        0,      // int
-                ).WillReturnResult(sqlmock.NewResult(0, 1))
+	prep := mock.ExpectPrepare("INSERT INTO network_policy")
+	prep.ExpectExec().
+		WithArgs(
+			"",               // str
+			"kind",           // str
+			flowID,           // []byte
+			"",               // str
+			"",               // str
+			"",               // str
+			"",               // str
+			"",               // str
+			"",               // str
+			"",               // str
+			spec,             // []byte
+			sqlmock.AnyArg(), // uint64
+			sqlmock.AnyArg(), // uint64
+		).WillReturnResult(sqlmock.NewResult(0, 1))
 
-        nfe := []types.KnoxNetworkPolicy{
-                types.KnoxNetworkPolicy{
-                        Kind: "kind",
-                },
-        }
+	nfe := []types.KnoxNetworkPolicy{
+		types.KnoxNetworkPolicy{
+			Kind: "kind",
+		},
+	}
 
-        err := InsertNetworkPoliciesToSQLite(types.ConfigDB{DBDriver: "sqlite3"}, nfe)
-        assert.NoError(t, err)
+	err := InsertNetworkPoliciesToSQLite(types.ConfigDB{DBDriver: "sqlite3"}, nfe)
+	assert.NoError(t, err)
 
-        if err := mock.ExpectationsWereMet(); err != nil {
-                t.Errorf(Unmet+"%s", err)
-        }
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf(Unmet+"%s", err)
+	}
 }

--- a/src/networkpolicy/helperFunctions.go
+++ b/src/networkpolicy/helperFunctions.go
@@ -127,6 +127,10 @@ func FilterNetworkLogsByConfig(logs []types.KnoxNetworkLog, pods []types.Pod) []
 			continue
 		}
 
+		if log.Protocol == libs.IPProtocolUDP && log.Direction == "TRAFFIC_DIRECTION_UNKNOWN" {
+			continue
+		}
+
 		if log.Protocol == libs.IPProtocolUDP && log.IsReply {
 			continue
 		}

--- a/src/networkpolicy/helperFunctions.go
+++ b/src/networkpolicy/helperFunctions.go
@@ -746,7 +746,7 @@ func clearTrackFlowIDMaps() {
 // == File Outputs == //
 // ================== //
 
-func WriteNetworkPoliciesToFile(cluster, namespace string, services []types.Service) {
+func WriteNetworkPoliciesToFile(cluster, namespace string) {
 	// retrieve the latest policies from the db
 	latestPolicies := libs.GetNetworkPolicies(CfgDB, cluster, namespace, "latest", "", "")
 
@@ -754,16 +754,16 @@ func WriteNetworkPoliciesToFile(cluster, namespace string, services []types.Serv
 	// libs.WriteKnoxNetPolicyToYamlFile(namespace, latestPolicies)
 
 	// convert knoxPolicy to CiliumPolicy
-	ciliumPolicies := plugin.ConvertKnoxPoliciesToCiliumPolicies(services, latestPolicies)
+	ciliumPolicies := plugin.ConvertKnoxPoliciesToCiliumPolicies(latestPolicies)
 
 	// write discovered policies to files
 	libs.WriteCiliumPolicyToYamlFile(namespace, ciliumPolicies)
 }
 
 func GetNetPolicy(cluster, namespace string) *wpb.WorkerResponse {
-	var services []types.Service
 	latestPolicies := libs.GetNetworkPolicies(CfgDB, cluster, namespace, "latest", "", "")
-	ciliumPolicies := plugin.ConvertKnoxPoliciesToCiliumPolicies(services, latestPolicies)
+	log.Info().Msgf("No. of latestPolicies - %d", len(latestPolicies))
+	ciliumPolicies := plugin.ConvertKnoxPoliciesToCiliumPolicies(latestPolicies)
 
 	var response wpb.WorkerResponse
 	for i := range ciliumPolicies {

--- a/src/networkpolicy/networkPolicy.go
+++ b/src/networkpolicy/networkPolicy.go
@@ -1643,7 +1643,7 @@ func PopulateNetworkPoliciesFromNetworkLogs(networkLogs []types.KnoxNetworkLog) 
 
 				// write discovered policies to file
 				if strings.Contains(NetworkPolicyTo, "file") {
-					WriteNetworkPoliciesToFile(clusterName, namespace, services)
+					WriteNetworkPoliciesToFile(clusterName, namespace)
 				}
 
 				log.Info().Msgf("-> Network policy discovery done for namespace: [%s], [%d] policies discovered", namespace, len(newNetPolicies))

--- a/src/plugin/cilium.go
+++ b/src/plugin/cilium.go
@@ -537,7 +537,7 @@ func buildNewCiliumNetworkPolicy(inPolicy types.KnoxNetworkPolicy) types.CiliumN
 	return ciliumPolicy
 }
 
-func ConvertKnoxNetworkPolicyToCiliumPolicy(services []types.Service, inPolicy types.KnoxNetworkPolicy) types.CiliumNetworkPolicy {
+func ConvertKnoxNetworkPolicyToCiliumPolicy(inPolicy types.KnoxNetworkPolicy) types.CiliumNetworkPolicy {
 	ciliumPolicy := buildNewCiliumNetworkPolicy(inPolicy)
 
 	// ====== //
@@ -738,11 +738,11 @@ func ConvertKnoxNetworkPolicyToCiliumPolicy(services []types.Service, inPolicy t
 	return ciliumPolicy
 }
 
-func ConvertKnoxPoliciesToCiliumPolicies(services []types.Service, policies []types.KnoxNetworkPolicy) []types.CiliumNetworkPolicy {
+func ConvertKnoxPoliciesToCiliumPolicies(policies []types.KnoxNetworkPolicy) []types.CiliumNetworkPolicy {
 	ciliumPolicies := []types.CiliumNetworkPolicy{}
 
 	for _, policy := range policies {
-		ciliumPolicy := ConvertKnoxNetworkPolicyToCiliumPolicy(services, policy)
+		ciliumPolicy := ConvertKnoxNetworkPolicyToCiliumPolicy(policy)
 		ciliumPolicies = append(ciliumPolicies, ciliumPolicy)
 	}
 

--- a/src/plugin/cilium_test.go
+++ b/src/plugin/cilium_test.go
@@ -177,9 +177,7 @@ func TestConvertKnoxPolicyToCiliumPolicy(t *testing.T) {
 	expected := &types.CiliumNetworkPolicy{}
 	json.Unmarshal(ciliumBytes, expected)
 
-	svcs := []types.Service{}
-
-	actual := ConvertKnoxNetworkPolicyToCiliumPolicy(svcs, *knoxPolicy)
+	actual := ConvertKnoxNetworkPolicyToCiliumPolicy(*knoxPolicy)
 	if !cmp.Equal(*expected, actual) {
 		t.Errorf("they should be equal %v %v", expected, actual)
 	}

--- a/src/server/grpcServer.go
+++ b/src/server/grpcServer.go
@@ -107,7 +107,7 @@ func (s *workerServer) Convert(ctx context.Context, in *wpb.WorkerRequest) (*wpb
 	if in.GetPolicytype() == "network" {
 		log.Info().Msg("Convert network policy called")
 		networker.InitNetPolicyDiscoveryConfiguration()
-		networker.WriteNetworkPoliciesToFile(in.GetClustername(), in.GetNamespace(), []types.Service{})
+		networker.WriteNetworkPoliciesToFile(in.GetClustername(), in.GetNamespace())
 		return networker.GetNetPolicy(in.Clustername, in.Namespace), nil
 	} else if in.GetPolicytype() == "system" {
 		log.Info().Msg("Convert system policy called")

--- a/src/types/policyData.go
+++ b/src/types/policyData.go
@@ -16,10 +16,18 @@ type SpecICMP struct {
 	Type   uint8  `json:"type" yaml:"type,omitempty" bson:"type,omitempty"`
 }
 
+func (x SpecICMP) Equal(y SpecICMP) bool {
+	return x.Family == y.Family && x.Type == y.Type
+}
+
 // SpecPort Structure
 type SpecPort struct {
 	Port     string `json:"port,omitempty" yaml:"port,omitempty" bson:"port,omitempty"`
 	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty" bson:"protocol,omitempty"`
+}
+
+func (x SpecPort) Equal(y SpecPort) bool {
+	return x.Port == y.Port && x.Protocol == y.Protocol
 }
 
 // SpecService Structure
@@ -69,6 +77,36 @@ type Egress struct {
 	ToHTTPs    []SpecHTTP    `json:"toHTTPs,omitempty" yaml:"toHTTPs,omitempty" bson:"toHTTPs,omitempty"`
 }
 
+type L47Rule interface {
+	GetICMPRules() []SpecICMP
+	GetPortRules() []SpecPort
+	GetHTTPRules() []SpecHTTP
+}
+
+func (x Ingress) GetICMPRules() []SpecICMP {
+	return x.ICMPs
+}
+
+func (x Ingress) GetPortRules() []SpecPort {
+	return x.ToPorts
+}
+
+func (x Ingress) GetHTTPRules() []SpecHTTP {
+	return x.ToHTTPs
+}
+
+func (x Egress) GetICMPRules() []SpecICMP {
+	return x.ICMPs
+}
+
+func (x Egress) GetPortRules() []SpecPort {
+	return x.ToPorts
+}
+
+func (x Egress) GetHTTPRules() []SpecHTTP {
+	return x.ToHTTPs
+}
+
 // Spec Structure
 type Spec struct {
 	Selector Selector `json:"selector,omitempty" yaml:"selector,omitempty" bson:"selector,omitempty"`
@@ -90,6 +128,7 @@ type KnoxNetworkPolicy struct {
 	Spec Spec `json:"spec,omitempty" yaml:"spec,omitempty" bson:"spec,omitempty"`
 
 	GeneratedTime int64 `json:"generatedTime,omitempty" yaml:"generatedTime,omitempty" bson:"generatedTime,omitempty"`
+	UpdatedTime   int64 `json:"updatedTime,omitempty" yaml:"updatedTime,omitempty" bson:"updatedTime,omitempty"`
 }
 
 // =========================== //


### PR DESCRIPTION
- Generate one policy per deployment/endpoint
- Added `updatedTime` flag in the DB `network_policy` table

Signed-off-by: Wazir Ahmed <wazir@accuknox.com>