### PR TITLE
 fix system service to use appropriate config file path

### DIFF
--- a/src/packaging/knoxAutoPolicy.service
+++ b/src/packaging/knoxAutoPolicy.service
@@ -3,8 +3,8 @@ Description=knoxAutoPolicy
 
 [Service]
 KillMode=process
-EnvironmentFile=/opt/knoxAutoPolicy/local-file.yaml
 WorkingDirectory=/opt/knoxAutoPolicy/
+Environment=CONF_FILE_NAME=local-file
 ExecStart=/opt/knoxAutoPolicy/src/knoxAutoPolicy
 
 [Install]


### PR DESCRIPTION
The knoxAutoPolicy.service is unable to use the configuration file. This PR will fix that issue.