### PR TITLE
change serviceaccount namespace to default

### DIFF
--- a/deployments/helm/values-dev.yaml
+++ b/deployments/helm/values-dev.yaml
@@ -18,7 +18,7 @@ namespace: accuknox-dev-knoxautopolicy
 
 #serviceaccountnamespace
 namespace:
-  name: explorer
+  name: default
 
 volumeMounts:
   - mountPath: /conf

--- a/deployments/helm/values-prod.yaml
+++ b/deployments/helm/values-prod.yaml
@@ -18,7 +18,7 @@ namespace: accuknox-knoxautopolicy
 
 #serviceaccountnamespace
 namespace:
-  name: explorer
+  name: default
 
 volumeMounts:
   - mountPath: /conf

--- a/deployments/helm/values-snapshot.yaml
+++ b/deployments/helm/values-snapshot.yaml
@@ -18,7 +18,7 @@ namespace: accuknox-dev-knoxautopolicy
 
 #serviceaccountnamespace
 namespace:
-  name: explorer
+  name: default
 
 volumeMounts:
   - mountPath: /conf

--- a/deployments/k8s/deployment.yaml
+++ b/deployments/k8s/deployment.yaml
@@ -136,4 +136,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: knoxautopolicy
-  namespace: explorer
+  namespace: default


### PR DESCRIPTION
we are no longer deploying the discovery-engine with the namespace as `explorer`.
this PR changes the service-account namespace to the `default`. 
Signed-off-by: rk <ramakant@accuknox.com>