### PR TITLE
Enable observability/store AD policy in DB

### DIFF
--- a/deployments/k8s/deployment.yaml
+++ b/deployments/k8s/deployment.yaml
@@ -60,8 +60,8 @@ data:
         cluster-info-from: "k8sclient"            # k8sclient|accuknox
 
     observability: 
-      enable: false
-      cron-job-time-interval: "0h0m5s"         # format: XhYmZs
+      enable: true
+      cron-job-time-interval: "0h0m10s"         # format: XhYmZs
       dbname: ./accuknox-obs.db
       system-observability: true
       network-observability: true

--- a/src/libs/dbHandler.go
+++ b/src/libs/dbHandler.go
@@ -263,6 +263,9 @@ func CreateTablesIfNotExist(cfg types.ConfigDB) {
 		if err := CreateTableNetworkLogsMySQL(cfg); err != nil {
 			log.Error().Msg(err.Error())
 		}
+		if err := CreatePolicyTableMySQL(cfg); err != nil {
+			log.Error().Msg(err.Error())
+		}
 	} else if cfg.DBDriver == "sqlite3" {
 		if err := CreateTableNetworkPolicySQLite(cfg); err != nil {
 			log.Error().Msg(err.Error())
@@ -277,6 +280,9 @@ func CreateTablesIfNotExist(cfg types.ConfigDB) {
 			log.Error().Msg(err.Error())
 		}
 		if err := CreateTableNetworkLogsSQLite(cfg); err != nil {
+			log.Error().Msg(err.Error())
+		}
+		if err := CreatePolicyTableSQLite(cfg); err != nil {
 			log.Error().Msg(err.Error())
 		}
 	}
@@ -338,4 +344,18 @@ func GetPodNames(cfg types.ConfigDB, filter types.ObsPodDetail) ([]string, error
 		res, err = GetPodNamesSQLite(cfg, filter)
 	}
 	return res, err
+}
+
+// =============== //
+// == Policy DB == //
+// =============== //
+
+func UpdateOrInsertPolicies(cfg types.ConfigDB, policies []types.Policy) error {
+	var err = errors.New("unknown db driver")
+	if cfg.DBDriver == "mysql" {
+		err = UpdateOrInsertPoliciesMySQL(cfg, policies)
+	} else if cfg.DBDriver == "sqlite3" {
+		err = UpdateOrInsertPoliciesSQLite(cfg, policies)
+	}
+	return err
 }

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -721,7 +721,7 @@ func CreatePolicyTableMySQL(cfg types.ConfigDB) error {
 			"	`namespace` varchar(50) DEFAULT NULL," +
 			"	`labels` text DEFAULT NULL," +
 			"	`policy_name` varchar(150) DEFAULT NULL," +
-			"	`policy_data` text DEFAULT NULL," +
+			"	`policy_yaml` text DEFAULT NULL," +
 			"	`updated_time` bigint NOT NULL," +
 			"	PRIMARY KEY (`id`)" +
 			"  );"
@@ -1642,7 +1642,7 @@ func updateOrInsertPolicyMySQL(policy types.Policy, db *sql.DB) error {
 	var err error
 	queryString := ` policy_name = ? `
 
-	query := "UPDATE " + PolicyTable_TableName + " SET policy_data=?, updated_time=? WHERE " + queryString + " "
+	query := "UPDATE " + PolicyTable_TableName + " SET policy_yaml=?, updated_time=? WHERE " + queryString + " "
 
 	updateStmt, err := db.Prepare(query)
 	if err != nil {
@@ -1651,7 +1651,7 @@ func updateOrInsertPolicyMySQL(policy types.Policy, db *sql.DB) error {
 	defer updateStmt.Close()
 
 	result, err := updateStmt.Exec(
-		policy.PolicyData,
+		policy.PolicyYaml,
 		ConvertStrToUnixTime("now"),
 		policy.PolicyName,
 	)
@@ -1665,7 +1665,7 @@ func updateOrInsertPolicyMySQL(policy types.Policy, db *sql.DB) error {
 	if err == nil && rowsAffected == 0 {
 
 		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTable_TableName +
-			"(type,cluster_name,namespace,labels,policy_name,policy_data,updatedtime) values(?,?,?,?,?,?,?)")
+			"(type,cluster_name,namespace,labels,policy_name,policy_yaml,updatedtime) values(?,?,?,?,?,?,?)")
 		if err != nil {
 			return err
 		}
@@ -1677,7 +1677,7 @@ func updateOrInsertPolicyMySQL(policy types.Policy, db *sql.DB) error {
 			policy.Namespace,
 			policy.Labels,
 			policy.PolicyName,
-			policy.PolicyData,
+			policy.PolicyYaml,
 			ConvertStrToUnixTime("now"),
 		)
 		if err != nil {

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -1666,7 +1666,7 @@ func updateOrInsertPolicyMySQL(policy types.Policy, db *sql.DB) error {
 	if err == nil && rowsAffected == 0 {
 
 		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTable_TableName +
-			"(type,kind,cluster_name,namespace,labels,policy_name,policy_yaml,updatedtime) values(?,?,?,?,?,?,?)")
+			"(type,kind,cluster_name,namespace,labels,policy_name,policy_yaml,updatedtime) values(?,?,?,?,?,?,?,?)")
 		if err != nil {
 			return err
 		}

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -1629,7 +1629,9 @@ func UpdateOrInsertPoliciesMySQL(cfg types.ConfigDB, policies []types.Policy) er
 	defer db.Close()
 
 	for _, pol := range policies {
-		updateOrInsertPolicyMySQL(pol, db)
+		if err := updateOrInsertPolicyMySQL(pol, db); err != nil {
+			log.Error().Msg(err.Error())
+		}
 	}
 
 	return nil

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -18,7 +18,7 @@ const TableNetworkPolicy_TableName = "network_policy"
 const TableSystemPolicy_TableName = "system_policy"
 const TableSystemLogs_TableName = "system_logs"
 const TableNetworkLogs_TableName = "network_logs"
-const PolicyTable_TableName = "policy_table"
+const PolicyTable_TableName = "policy_yaml"
 
 // ================ //
 // == Connection == //
@@ -717,6 +717,7 @@ func CreatePolicyTableMySQL(cfg types.ConfigDB) error {
 		"CREATE TABLE IF NOT EXISTS `" + tableName + "` (" +
 			"	`id` INTEGER AUTO_INCREMENT," +
 			"	`type` varchar(50) DEFAULT NULL," +
+			"	`kind` varchar(50) DEFAULT NULL," +
 			"	`cluster_name` varchar(50) DEFAULT NULL," +
 			"	`namespace` varchar(50) DEFAULT NULL," +
 			"	`labels` text DEFAULT NULL," +
@@ -1665,7 +1666,7 @@ func updateOrInsertPolicyMySQL(policy types.Policy, db *sql.DB) error {
 	if err == nil && rowsAffected == 0 {
 
 		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTable_TableName +
-			"(type,cluster_name,namespace,labels,policy_name,policy_yaml,updatedtime) values(?,?,?,?,?,?,?)")
+			"(type,kind,cluster_name,namespace,labels,policy_name,policy_yaml,updatedtime) values(?,?,?,?,?,?,?)")
 		if err != nil {
 			return err
 		}
@@ -1673,6 +1674,7 @@ func updateOrInsertPolicyMySQL(policy types.Policy, db *sql.DB) error {
 
 		_, err = insertStmt.Exec(
 			policy.Type,
+			policy.Kind,
 			policy.ClusterName,
 			policy.Namespace,
 			policy.Labels,

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -1673,7 +1673,7 @@ func updateOrInsertPolicyMySQL(policy types.Policy, db *sql.DB) error {
 
 		_, err = insertStmt.Exec(
 			policy.Type,
-			policy.Clustername,
+			policy.ClusterName,
 			policy.Namespace,
 			policy.Labels,
 			policy.PolicyName,

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -1630,7 +1630,8 @@ func updateOrInsertPolicySQLite(db *sql.DB, policy types.Policy) error {
 	rowsAffected, err := result.RowsAffected()
 
 	if err == nil && rowsAffected == 0 {
-		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTableSQLite_TableName + " (type,kind,cluster_name,namespace,labels,policy_name,policy_yaml,updated_time) values(?,?,?,?,?,?,?,?)")
+		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTableSQLite_TableName +
+			" (type,kind,cluster_name,namespace,labels,policy_name,policy_yaml,updated_time) values(?,?,?,?,?,?,?,?)")
 		if err != nil {
 			return err
 		}

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -1637,7 +1637,7 @@ func updateOrInsertPolicySQLite(db *sql.DB, policy types.Policy) error {
 
 		_, err = insertStmt.Exec(
 			policy.Type,
-			policy.Clustername,
+			policy.ClusterName,
 			policy.Namespace,
 			policy.Labels,
 			policy.PolicyName,

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -19,6 +19,7 @@ const TableNetworkPolicySQLite_TableName = "network_policy"
 const TableSystemPolicySQLite_TableName = "system_policy"
 const TableSystemLogsSQLite_TableName = "system_logs"
 const TableNetworkLogsSQLite_TableName = "network_logs"
+const PolicyTableSQLite_TableName = "policy_table"
 
 // ================ //
 // == Connection == //
@@ -676,6 +677,29 @@ func CreateTableNetworkLogsSQLite(cfg types.ConfigDB) error {
 	return err
 }
 
+func CreatePolicyTableSQLite(cfg types.ConfigDB) error {
+	db := connectSQLite(cfg, cfg.SQLiteDBPath)
+	defer db.Close()
+
+	tableName := PolicyTableSQLite_TableName
+
+	query :=
+		"CREATE TABLE IF NOT EXISTS `" + tableName + "` (" +
+			"	`id` INTEGER AUTO_INCREMENT," +
+			"	`type` varchar(50) DEFAULT NULL," +
+			"	`cluster_name` varchar(50) DEFAULT NULL," +
+			"	`namespace` varchar(50) DEFAULT NULL," +
+			"	`labels` text DEFAULT NULL," +
+			"	`policy_name` varchar(150) DEFAULT NULL," +
+			"	`policy_data` text DEFAULT NULL," +
+			"	`updated_time` bigint NOT NULL," +
+			"	PRIMARY KEY (`id`)" +
+			"  );"
+
+	_, err := db.Exec(query)
+	return err
+}
+
 func concatWhereClauseSQLite(whereClause *string, field string) {
 	if *whereClause == "" {
 		*whereClause = " WHERE "
@@ -877,20 +901,24 @@ func UpdateWorkloadProcessFileSetSQLite(cfg types.ConfigDB, wpfs types.WorkloadP
 	return err
 }
 
+// =================== //
+// == Observability == //
+// =================== //
+
 // UpdateOrInsertKubearmorLogsSQLite -- Update existing log or insert a new log into DB
 func UpdateOrInsertKubearmorLogsSQLite(cfg types.ConfigDB, kubearmorlogmap map[types.KubeArmorLog]int) error {
 	db := connectSQLite(cfg, config.GetCfgObservabilityDBName())
 	defer db.Close()
 
 	start := time.Now().UnixNano() / int64(time.Millisecond)
-	log.Info().Msgf("sqlite update or insert %d\n", len(kubearmorlogmap))
+	log.Info().Msgf("sqlite update or insert %d", len(kubearmorlogmap))
 	for kubearmorlog, count := range kubearmorlogmap {
 		if err := updateOrInsertKubearmorLogsSQLite(db, kubearmorlog, count); err != nil {
 			log.Error().Msg(err.Error())
 		}
 	}
 	end := time.Now().UnixNano() / int64(time.Millisecond)
-	log.Info().Msgf("return sqlite update or insert %d time-taken-ms:%d\n", len(kubearmorlogmap), end-start)
+	log.Info().Msgf("return sqlite update or insert %d time-taken-ms:%d", len(kubearmorlogmap), end-start)
 	return nil
 }
 
@@ -1559,4 +1587,65 @@ func GetPodNamesSQLite(cfg types.ConfigDB, filter types.ObsPodDetail) ([]string,
 	}
 
 	return resPodNames, err
+}
+
+// =============== //
+// == Policy DB == //
+// =============== //
+
+func UpdateOrInsertPoliciesSQLite(cfg types.ConfigDB, policies []types.Policy) error {
+	db := connectSQLite(cfg, cfg.SQLiteDBPath)
+	defer db.Close()
+
+	for _, pol := range policies {
+		updateOrInsertPolicySQLite(db, pol)
+	}
+
+	return nil
+}
+
+func updateOrInsertPolicySQLite(db *sql.DB, policy types.Policy) error {
+	var err error
+
+	query := "UPDATE " + PolicyTableSQLite_TableName + " SET policy_data = ?, updated_time = ? WHERE policy_name = ?"
+	updateStmt, err := db.Prepare(query)
+	if err != nil {
+		return err
+	}
+	defer updateStmt.Close()
+
+	result, err := updateStmt.Exec(
+		policy.PolicyData,
+		ConvertStrToUnixTime("now"),
+		policy.PolicyName,
+	)
+	if err != nil {
+		log.Error().Msg(err.Error())
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+
+	if err == nil && rowsAffected == 0 {
+		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTableSQLite_TableName + " (type,cluster_name,namespace,labels,policy_name,policy_data,updated_time) values(?,?,?,?,?,?,?)")
+		if err != nil {
+			return err
+		}
+		defer insertStmt.Close()
+
+		_, err = insertStmt.Exec(
+			policy.Type,
+			policy.Clustername,
+			policy.Namespace,
+			policy.Labels,
+			policy.PolicyName,
+			policy.PolicyData,
+			ConvertStrToUnixTime("now"),
+		)
+		if err != nil {
+			log.Error().Msg(err.Error())
+		}
+	}
+
+	return err
 }

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -691,7 +691,7 @@ func CreatePolicyTableSQLite(cfg types.ConfigDB) error {
 			"	`namespace` varchar(50) DEFAULT NULL," +
 			"	`labels` text DEFAULT NULL," +
 			"	`policy_name` varchar(150) DEFAULT NULL," +
-			"	`policy_data` text DEFAULT NULL," +
+			"	`policy_yaml` text DEFAULT NULL," +
 			"	`updated_time` bigint NOT NULL," +
 			"	PRIMARY KEY (`id`)" +
 			"  );"
@@ -1609,7 +1609,7 @@ func UpdateOrInsertPoliciesSQLite(cfg types.ConfigDB, policies []types.Policy) e
 func updateOrInsertPolicySQLite(db *sql.DB, policy types.Policy) error {
 	var err error
 
-	query := "UPDATE " + PolicyTableSQLite_TableName + " SET policy_data = ?, updated_time = ? WHERE policy_name = ?"
+	query := "UPDATE " + PolicyTableSQLite_TableName + " SET policy_yaml = ?, updated_time = ? WHERE policy_name = ?"
 	updateStmt, err := db.Prepare(query)
 	if err != nil {
 		return err
@@ -1617,7 +1617,7 @@ func updateOrInsertPolicySQLite(db *sql.DB, policy types.Policy) error {
 	defer updateStmt.Close()
 
 	result, err := updateStmt.Exec(
-		policy.PolicyData,
+		policy.PolicyYaml,
 		ConvertStrToUnixTime("now"),
 		policy.PolicyName,
 	)
@@ -1629,7 +1629,7 @@ func updateOrInsertPolicySQLite(db *sql.DB, policy types.Policy) error {
 	rowsAffected, err := result.RowsAffected()
 
 	if err == nil && rowsAffected == 0 {
-		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTableSQLite_TableName + " (type,cluster_name,namespace,labels,policy_name,policy_data,updated_time) values(?,?,?,?,?,?,?)")
+		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTableSQLite_TableName + " (type,cluster_name,namespace,labels,policy_name,policy_yaml,updated_time) values(?,?,?,?,?,?,?)")
 		if err != nil {
 			return err
 		}
@@ -1641,7 +1641,7 @@ func updateOrInsertPolicySQLite(db *sql.DB, policy types.Policy) error {
 			policy.Namespace,
 			policy.Labels,
 			policy.PolicyName,
-			policy.PolicyData,
+			policy.PolicyYaml,
 			ConvertStrToUnixTime("now"),
 		)
 		if err != nil {

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -1598,7 +1598,9 @@ func UpdateOrInsertPoliciesSQLite(cfg types.ConfigDB, policies []types.Policy) e
 	defer db.Close()
 
 	for _, pol := range policies {
-		updateOrInsertPolicySQLite(db, pol)
+		if err := updateOrInsertPolicySQLite(db, pol); err != nil {
+			log.Error().Msg(err.Error())
+		}
 	}
 
 	return nil

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -19,7 +19,7 @@ const TableNetworkPolicySQLite_TableName = "network_policy"
 const TableSystemPolicySQLite_TableName = "system_policy"
 const TableSystemLogsSQLite_TableName = "system_logs"
 const TableNetworkLogsSQLite_TableName = "network_logs"
-const PolicyTableSQLite_TableName = "policy_table"
+const PolicyTableSQLite_TableName = "policy_yaml"
 
 // ================ //
 // == Connection == //
@@ -687,6 +687,7 @@ func CreatePolicyTableSQLite(cfg types.ConfigDB) error {
 		"CREATE TABLE IF NOT EXISTS `" + tableName + "` (" +
 			"	`id` INTEGER AUTO_INCREMENT," +
 			"	`type` varchar(50) DEFAULT NULL," +
+			"	`kind` varchar(50) DEFAULT NULL," +
 			"	`cluster_name` varchar(50) DEFAULT NULL," +
 			"	`namespace` varchar(50) DEFAULT NULL," +
 			"	`labels` text DEFAULT NULL," +
@@ -1629,7 +1630,7 @@ func updateOrInsertPolicySQLite(db *sql.DB, policy types.Policy) error {
 	rowsAffected, err := result.RowsAffected()
 
 	if err == nil && rowsAffected == 0 {
-		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTableSQLite_TableName + " (type,cluster_name,namespace,labels,policy_name,policy_yaml,updated_time) values(?,?,?,?,?,?,?)")
+		insertStmt, err := db.Prepare("INSERT INTO " + PolicyTableSQLite_TableName + " (type,kind,cluster_name,namespace,labels,policy_name,policy_yaml,updated_time) values(?,?,?,?,?,?,?,?)")
 		if err != nil {
 			return err
 		}
@@ -1637,6 +1638,7 @@ func updateOrInsertPolicySQLite(db *sql.DB, policy types.Policy) error {
 
 		_, err = insertStmt.Exec(
 			policy.Type,
+			policy.Kind,
 			policy.ClusterName,
 			policy.Namespace,
 			policy.Labels,

--- a/src/networkpolicy/networkPolicy.go
+++ b/src/networkpolicy/networkPolicy.go
@@ -2164,12 +2164,19 @@ func writeNetworkPoliciesYamlToDB(policies []types.KnoxNetworkPolicy) {
 		}
 		policyYaml := string(yamlBytes)
 
-		for k, v := range ciliumPolicy.Spec.EndpointSelector.MatchLabels {
-			label = k + "=" + v
+		if ciliumPolicy.Spec.NodeSelector.MatchLabels != nil {
+			for k, v := range ciliumPolicy.Spec.NodeSelector.MatchLabels {
+				label = k + "=" + v
+			}
+		} else {
+			for k, v := range ciliumPolicy.Spec.EndpointSelector.MatchLabels {
+				label = k + "=" + v
+			}
 		}
 
 		res = append(res, types.Policy{
 			Type:        "network",
+			Kind:        ciliumPolicy.Kind,
 			PolicyName:  ciliumPolicy.Metadata["name"],
 			Namespace:   ciliumPolicy.Metadata["namespace"],
 			ClusterName: clusternames[index],

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -1361,7 +1361,7 @@ func insertSysPoliciesYamlToDB(policies []types.KnoxSystemPolicy) {
 			Namespace:   kubearmorPolicy.Metadata["namespace"],
 			Clustername: kubearmorPolicy.Metadata["clusterName"],
 			Labels:      label,
-			PolicyData:  policyData,
+			PolicyYaml:  policyData,
 		})
 	}
 

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -1354,7 +1354,7 @@ func insertSysPoliciesYamlToDB(policies []types.KnoxSystemPolicy) {
 			Type:        "system",
 			PolicyName:  kubearmorPolicy.Metadata["name"],
 			Namespace:   kubearmorPolicy.Metadata["namespace"],
-			Clustername: kubearmorPolicy.Metadata["clusterName"],
+			ClusterName: kubearmorPolicy.Metadata["clusterName"],
 			Labels:      label,
 			PolicyYaml:  policyYaml,
 		})

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -1352,6 +1352,7 @@ func insertSysPoliciesYamlToDB(policies []types.KnoxSystemPolicy) {
 
 		res = append(res, types.Policy{
 			Type:        "system",
+			Kind:        kubearmorPolicy.Kind,
 			PolicyName:  kubearmorPolicy.Metadata["name"],
 			Namespace:   kubearmorPolicy.Metadata["namespace"],
 			ClusterName: kubearmorPolicy.Metadata["clusterName"],

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -1339,7 +1339,7 @@ func insertSysPoliciesYamlToDB(policies []types.KnoxSystemPolicy) {
 	for _, kubearmorPolicy := range kubeArmorPolicies {
 		var label string
 
-		jsonBytes, err := json.Marshal(&kubearmorPolicy)
+		jsonBytes, err := json.Marshal(kubearmorPolicy)
 		if err != nil {
 			log.Error().Msg(err.Error())
 			continue

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -986,7 +986,7 @@ func updateSysPolicies() {
 
 	wpfsPolicies := populateKnoxSysPolicyFromWPFSDb("", "", "", "")
 
-	go insertSysPoliciesYamlToDB(wpfsPolicies)
+	insertSysPoliciesYamlToDB(wpfsPolicies)
 
 	for _, wpfsPolicy := range wpfsPolicies {
 		isPolicyExist = false
@@ -1328,10 +1328,6 @@ func GenFileSetForAllPodsInCluster(clusterName string, pods []types.Pod, settype
 
 func insertSysPoliciesYamlToDB(policies []types.KnoxSystemPolicy) {
 	kubeArmorPolicies := plugin.ConvertKnoxSystemPolicyToKubeArmorPolicy(policies)
-
-	if len(kubeArmorPolicies) <= 0 {
-		return
-	}
 
 	res := []types.Policy{}
 

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -1327,7 +1327,6 @@ func GenFileSetForAllPodsInCluster(clusterName string, pods []types.Pod, settype
 }
 
 func insertSysPoliciesYamlToDB(policies []types.KnoxSystemPolicy) {
-	//policies := libs.GetSystemPolicies(CfgDB, "", "")
 	kubeArmorPolicies := plugin.ConvertKnoxSystemPolicyToKubeArmorPolicy(policies)
 
 	if len(kubeArmorPolicies) <= 0 {
@@ -1349,7 +1348,7 @@ func insertSysPoliciesYamlToDB(policies []types.KnoxSystemPolicy) {
 			log.Error().Msg(err.Error())
 			continue
 		}
-		policyData := string(yamlBytes)
+		policyYaml := string(yamlBytes)
 
 		for k, v := range kubearmorPolicy.Spec.Selector.MatchLabels {
 			label = k + "=" + v
@@ -1361,7 +1360,7 @@ func insertSysPoliciesYamlToDB(policies []types.KnoxSystemPolicy) {
 			Namespace:   kubearmorPolicy.Metadata["namespace"],
 			Clustername: kubearmorPolicy.Metadata["clusterName"],
 			Labels:      label,
-			PolicyYaml:  policyData,
+			PolicyYaml:  policyYaml,
 		})
 	}
 

--- a/src/types/policyData.go
+++ b/src/types/policyData.go
@@ -316,7 +316,7 @@ type KubeArmorPolicy struct {
 type Policy struct {
 	Type        string
 	Namespace   string
-	Clustername string
+	ClusterName string
 	Labels      string
 	PolicyName  string
 	PolicyYaml  string

--- a/src/types/policyData.go
+++ b/src/types/policyData.go
@@ -319,5 +319,5 @@ type Policy struct {
 	Clustername string
 	Labels      string
 	PolicyName  string
-	PolicyData  string
+	PolicyYaml  string
 }

--- a/src/types/policyData.go
+++ b/src/types/policyData.go
@@ -314,10 +314,11 @@ type KubeArmorPolicy struct {
 // == Policy DB == //
 // =============== //
 type Policy struct {
-	Type        string
-	Namespace   string
-	ClusterName string
-	Labels      string
-	PolicyName  string
-	PolicyYaml  string
+	Type        string `json:"type,omitempty"`
+	Kind        string `json:"kind,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
+	ClusterName string `json:"cluster_name,omitempty"`
+	Labels      string `json:"labels,omitempty"`
+	PolicyName  string `json:"policy_name,omitempty"`
+	PolicyYaml  string `json:"policy_yaml,omitempty"`
 }

--- a/src/types/policyData.go
+++ b/src/types/policyData.go
@@ -309,3 +309,15 @@ type KubeArmorPolicy struct {
 
 	Spec KnoxSystemSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
 }
+
+// =============== //
+// == Policy DB == //
+// =============== //
+type Policy struct {
+	Type        string
+	Namespace   string
+	Clustername string
+	Labels      string
+	PolicyName  string
+	PolicyData  string
+}


### PR DESCRIPTION
1. Enable Observability
2. Add AD policy yaml to DB(policy_table) (https://kloudone.atlassian.net/browse/AK-10946) 

Signed-off-by: Eswar Rajan Subramanian [eswar@accuknox.com](mailto:eswar@accuknox.com) 