### PR TITLE
Filter file paths for relative paths

### DIFF
--- a/src/plugin/kubearmor.go
+++ b/src/plugin/kubearmor.go
@@ -422,6 +422,11 @@ func StartKubeArmorRelay(StopChan chan struct{}, cfg types.ConfigKubeArmorRelay)
 					continue
 				}
 
+				if !strings.HasPrefix(res.Resource, "/") {
+					log.Warn().Msgf("Relative path found: %v", res)
+					continue
+				}
+
 				KubeArmorRelayLogsMutex.Lock()
 				KubeArmorRelayLogs = append(KubeArmorRelayLogs, res)
 				KubeArmorRelayLogsMutex.Unlock()
@@ -463,7 +468,7 @@ func StartKubeArmorRelay(StopChan chan struct{}, cfg types.ConfigKubeArmorRelay)
 					return
 				}
 
-				log := pb.Log{
+				kubearmorLog := pb.Log{
 					ClusterName:   res.ClusterName,
 					ContainerName: res.ContainerName,
 					HostName:      res.HostName,
@@ -477,26 +482,31 @@ func StartKubeArmorRelay(StopChan chan struct{}, cfg types.ConfigKubeArmorRelay)
 					Type:          res.Type,
 				}
 
-				if ignoreLogFromRelayWithNamespace(nsFilter, nsNotFilter, &log) {
+				if ignoreLogFromRelayWithNamespace(nsFilter, nsNotFilter, &kubearmorLog) {
 					continue
 				}
 
-				if ignoreLogFromRelayWithSource(fromSourceFilter, &log) {
+				if ignoreLogFromRelayWithSource(fromSourceFilter, &kubearmorLog) {
+					continue
+				}
+
+				if !strings.HasPrefix(res.Resource, "/") {
+					log.Warn().Msgf("Relative path found: %v", res)
 					continue
 				}
 
 				KubeArmorRelayLogsMutex.Lock()
-				KubeArmorRelayLogs = append(KubeArmorRelayLogs, &log)
+				KubeArmorRelayLogs = append(KubeArmorRelayLogs, &kubearmorLog)
 				KubeArmorRelayLogsMutex.Unlock()
 
 				if config.GetCfgObservabilityEnable() {
-					obs.ProcessKubearmorAlert(&log)
+					obs.ProcessKubearmorAlert(&kubearmorLog)
 				}
 
 				if config.CurrentCfg.ConfigNetPolicy.NetworkLogFrom == "kubearmor" {
-					if log.Operation == "Network" && (strings.Contains(log.Data, "tcp_") ||
-						strings.Contains(log.Resource, "UDP")) {
-						KubeArmorNetworkLogs = append(KubeArmorNetworkLogs, &log)
+					if kubearmorLog.Operation == "Network" && (strings.Contains(kubearmorLog.Data, "tcp_") ||
+						strings.Contains(kubearmorLog.Resource, "UDP")) {
+						KubeArmorNetworkLogs = append(KubeArmorNetworkLogs, &kubearmorLog)
 					}
 				}
 			}


### PR DESCRIPTION
Prevent relative paths logs from being sent to the discovery engine