### PR TITLE
removed arm64 build support

### DIFF
--- a/src/build/push_knoxautopolicy.sh
+++ b/src/build/push_knoxautopolicy.sh
@@ -5,7 +5,8 @@ cd $AUTOPOL_HOME
 AUTOPOL_SRC_HOME=$AUTOPOL_HOME/src
 
 [[ "$REPO" == "" ]] && REPO="accuknox/knoxautopolicy"
-[[ "$PLATFORMS" == "" ]] && PLATFORMS="linux/amd64,linux/arm64/v8"
+[[ "$PLATFORMS" == "" ]] && PLATFORMS="linux/amd64"
+#[[ "$PLATFORMS" == "" ]] && PLATFORMS="linux/amd64,linux/arm64/v8"
 
 # check version
 VERSION=`git rev-parse --abbrev-ref HEAD`


### PR DESCRIPTION
linking is failing due to kafka lib issue on arm64.

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>