### PR TITLE
Purge Old DB Entries

### DIFF
--- a/src/conf/local-file.yaml
+++ b/src/conf/local-file.yaml
@@ -44,6 +44,13 @@ publisher:
   enable: true
   cron-job-time-interval: "0h1m00s"         # format: XhYmZs
 
+purge-old-db-entries:
+  enable: true 
+  cron-job-time-interval: "240h0m00s"      # format: XhYmZs
+  dbname: 
+   - ./accuknox-obs.db
+   - ./accuknox-pol.db
+
 database:
   driver: sqlite3
   host: 127.0.0.1

--- a/src/config/configManager.go
+++ b/src/config/configManager.go
@@ -195,6 +195,13 @@ func LoadConfigFromFile() {
 		CronJobTimeInterval: "@every " + viper.GetString("publisher.cron-job-time-interval"),
 	}
 
+	// for purge old entries from db
+	CurrentCfg.ConfigPurgeOldDBEntries = types.ConfigPurgeOldDBEntries{
+		Enable:              viper.GetBool("purge-old-db-entries.enable"),
+		CronJobTimeInterval: "@every " + viper.GetString("purge-old-db-entries.cron-job-time-interval"),
+		DBName:              viper.GetStringSlice("purge-old-db-entries.dbname"),
+	}
+
 	// load database
 	CurrentCfg.ConfigDB = LoadConfigDB()
 
@@ -456,4 +463,20 @@ func GetCfgPublisherEnable() bool {
 
 func GetCfgPublisherCronJobTime() string {
 	return CurrentCfg.ConfigPublisher.CronJobTimeInterval
+}
+
+// ========================== //
+// == Purge Old DB Entries == //
+// ========================== //
+
+func GetCfgPurgeOldDBEntriesEnable() bool {
+	return CurrentCfg.ConfigPurgeOldDBEntries.Enable
+}
+
+func GetCfgPurgeOldDBEntriesCronJobTime() string {
+	return CurrentCfg.ConfigPurgeOldDBEntries.CronJobTimeInterval
+}
+
+func GetCfgPurgeOldDBEntriesDBName() []string {
+	return CurrentCfg.ConfigPurgeOldDBEntries.DBName
 }

--- a/src/libs/dbHandler.go
+++ b/src/libs/dbHandler.go
@@ -3,7 +3,6 @@ package libs
 import (
 	"database/sql"
 	"errors"
-	"sync"
 
 	cfg "github.com/accuknox/auto-policy-discovery/src/config"
 	logger "github.com/accuknox/auto-policy-discovery/src/logging"
@@ -625,29 +624,16 @@ func getSysSummarySQL(db *sql.DB, dbName string, filterOptions types.SystemSumma
 // == Purge Old DB Entries Cron Job ==  //
 // ==================================== //
 var (
-	CfgDB                                      types.ConfigDB
-	SystemLogsMutex, NetworkLogsMutex, DBMutex *sync.Mutex
-	PurgeDBCronJob                             *cron.Cron
-	PurgeDBMap                                 types.ConfigPurgeOldDBEntries
+	CfgDB          types.ConfigDB
+	PurgeDBCronJob *cron.Cron
+	PurgeDBMap     types.ConfigPurgeOldDBEntries
 )
-
-func initMutex() {
-	DBMutex = &sync.Mutex{}
-	if cfg.GetCfgPurgeOldDBEntriesEnable() {
-		SystemLogsMutex = &sync.Mutex{}
-	}
-	if cfg.GetCfgPurgeOldDBEntriesEnable() {
-		NetworkLogsMutex = &sync.Mutex{}
-	}
-}
 
 func InitPurgeOldDBEntries() {
 	log = logger.GetInstance()
 	CfgDB = cfg.GetCfgDB()
 
 	if cfg.GetCfgPurgeOldDBEntriesEnable() {
-		// Init mutex
-		initMutex()
 
 		PurgeDBCronJob = cron.New()
 		err := PurgeDBCronJob.AddFunc(cfg.GetCfgPurgeOldDBEntriesCronJobTime(), PurgeOldDBEntriesCronJob) // time interval
@@ -662,7 +648,7 @@ func InitPurgeOldDBEntries() {
 
 func PurgeOldDBEntriesCronJob() {
 	if cfg.GetCfgPurgeOldDBEntriesEnable() {
-		go PurgeOldDBEntriesMySQL(types.ConfigDB{})
-		go PurgeOldDBEntriesSQLite(types.ConfigDB{})
+		PurgeOldDBEntriesMySQL(types.ConfigDB{})
+		PurgeOldDBEntriesSQLite(types.ConfigDB{})
 	}
 }

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/accuknox/auto-policy-discovery/src/config"
 	"github.com/accuknox/auto-policy-discovery/src/types"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -1723,4 +1724,25 @@ func GetSystemSummaryMySQL(cfg types.ConfigDB, filterOptions types.SystemSummary
 	res, err := getSysSummarySQL(db, TableSystemSummarySQLite, filterOptions)
 
 	return res, err
+}
+
+// ========================== //
+// == Purge Old DB Entries == //
+// ========================== //
+
+func PurgeOldDBEntriesMySQL(cfg types.ConfigDB) {
+	db := connectMySQL(cfg)
+	defer db.Close()
+
+	timeNow := (ConvertStrToUnixTime("now"))
+	purgeTime := (config.GetCfgPublisherCronJobTime()) //sec
+	PurgeTimeValue, err := strconv.ParseInt(purgeTime, 10, 64)
+	if err != nil {
+		log.Error().Msg(err.Error())
+	}
+	ConvertedValue := timeNow - PurgeTimeValue
+	query := "DELETE FROM system_summary WHERE updated_time < " + strconv.Itoa(int(ConvertedValue))
+	if _, err := db.Query(query); err != nil {
+		log.Error().Msg(err.Error())
+	}
 }

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -1730,7 +1730,7 @@ func GetSystemSummaryMySQL(cfg types.ConfigDB, filterOptions types.SystemSummary
 // == Purge Old DB Entries == //
 // ========================== //
 
-func PurgeOldDBEntriesMySQL(cfg types.ConfigDB) error {
+func PurgeOldDBEntriesMySQL(cfg types.ConfigDB) {
 	db := connectMySQL(cfg)
 	defer db.Close()
 
@@ -1739,12 +1739,10 @@ func PurgeOldDBEntriesMySQL(cfg types.ConfigDB) error {
 	PurgeTimeValue, err := strconv.ParseInt(purgeTime, 10, 64)
 	if err != nil {
 		log.Error().Msg(err.Error())
-		return err
 	}
 	ConvertedValue := timeNow - PurgeTimeValue
 	query := "DELETE FROM system_summary WHERE updated_time < " + strconv.Itoa(int(ConvertedValue))
 	if _, err := db.Query(query); err != nil {
-		return err
+		log.Error().Msg(err.Error())
 	}
-	return nil
 }

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/accuknox/auto-policy-discovery/src/config"
 	"github.com/accuknox/auto-policy-discovery/src/types"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -1723,4 +1724,27 @@ func GetSystemSummaryMySQL(cfg types.ConfigDB, filterOptions types.SystemSummary
 	res, err := getSysSummarySQL(db, TableSystemSummarySQLite, filterOptions)
 
 	return res, err
+}
+
+// ========================== //
+// == Purge Old DB Entries == //
+// ========================== //
+
+func PurgeOldDBEntriesMySQL(cfg types.ConfigDB) error {
+	db := connectMySQL(cfg)
+	defer db.Close()
+
+	timeNow := (ConvertStrToUnixTime("now"))
+	purgeTime := (config.GetCfgPublisherCronJobTime()) //sec
+	PurgeTimeValue, err := strconv.ParseInt(purgeTime, 10, 64)
+	if err != nil {
+		log.Error().Msg(err.Error())
+		return err
+	}
+	ConvertedValue := timeNow - PurgeTimeValue
+	query := "DELETE FROM system_summary WHERE updated_time < " + strconv.Itoa(int(ConvertedValue))
+	if _, err := db.Query(query); err != nil {
+		return err
+	}
+	return nil
 }

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -1728,3 +1728,25 @@ func GetSystemSummarySQLite(cfg types.ConfigDB, filterOptions types.SystemSummar
 
 	return res, err
 }
+
+// ========================== //
+// == Purge Old DB Entries == //
+// ========================== //
+func PurgeOldDBEntriesSQLite(cfg types.ConfigDB) error {
+	db := connectSQLite(cfg, cfg.SQLiteDBPath)
+	defer db.Close()
+
+	timeNow := (ConvertStrToUnixTime("now"))
+	purgeTime := (config.GetCfgPublisherCronJobTime()) //sec
+	PurgeTimeValue, err := strconv.ParseInt(purgeTime, 10, 64)
+	if err != nil {
+		log.Error().Msg(err.Error())
+		return err
+	}
+	ConvertedValue := timeNow - PurgeTimeValue
+	query := "DELETE FROM system_summary WHERE updated_time < " + strconv.Itoa(int(ConvertedValue))
+	if _, err := db.Query(query); err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -1728,3 +1728,23 @@ func GetSystemSummarySQLite(cfg types.ConfigDB, filterOptions types.SystemSummar
 
 	return res, err
 }
+
+// ========================== //
+// == Purge Old DB Entries == //
+// ========================== //
+func PurgeOldDBEntriesSQLite(cfg types.ConfigDB) {
+	db := connectSQLite(cfg, cfg.SQLiteDBPath)
+	defer db.Close()
+
+	timeNow := (ConvertStrToUnixTime("now"))
+	purgeTime := (config.GetCfgPublisherCronJobTime()) //sec
+	PurgeTimeValue, err := strconv.ParseInt(purgeTime, 10, 64)
+	if err != nil {
+		log.Error().Msg(err.Error())
+	}
+	ConvertedValue := timeNow - PurgeTimeValue
+	query := "DELETE FROM system_summary WHERE updated_time < " + strconv.Itoa(int(ConvertedValue))
+	if _, err := db.Query(query); err != nil {
+		log.Error().Msg(err.Error())
+	}
+}

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -1732,7 +1732,7 @@ func GetSystemSummarySQLite(cfg types.ConfigDB, filterOptions types.SystemSummar
 // ========================== //
 // == Purge Old DB Entries == //
 // ========================== //
-func PurgeOldDBEntriesSQLite(cfg types.ConfigDB) error {
+func PurgeOldDBEntriesSQLite(cfg types.ConfigDB) {
 	db := connectSQLite(cfg, cfg.SQLiteDBPath)
 	defer db.Close()
 
@@ -1741,12 +1741,10 @@ func PurgeOldDBEntriesSQLite(cfg types.ConfigDB) error {
 	PurgeTimeValue, err := strconv.ParseInt(purgeTime, 10, 64)
 	if err != nil {
 		log.Error().Msg(err.Error())
-		return err
 	}
 	ConvertedValue := timeNow - PurgeTimeValue
 	query := "DELETE FROM system_summary WHERE updated_time < " + strconv.Itoa(int(ConvertedValue))
 	if _, err := db.Query(query); err != nil {
-		return err
+		log.Error().Msg(err.Error())
 	}
-	return nil
 }

--- a/src/types/configData.go
+++ b/src/types/configData.go
@@ -110,6 +110,12 @@ type ConfigPublisher struct {
 	CronJobTimeInterval string `json:"cronjob_time_interval,omitempty" bson:"cronjob_time_interval,omitempty"`
 }
 
+type ConfigPurgeOldDBEntries struct {
+	Enable              bool     `json:"enable,omitempty" bson:"enable,omiempty"`
+	CronJobTimeInterval string   `json:"cronjob_time_interval,omitempty" bson:"cronjob_time_interval,omitempty"`
+	DBName              []string `json:"db_name,omitempty" bson:"db_name,omitempty"`
+}
+
 type Configuration struct {
 	ConfigName string `json:"config_name,omitempty" bson:"config_name,omitempty"`
 	Status     int    `json:"status,omitempty" bson:"status,omitempty"`
@@ -121,9 +127,10 @@ type Configuration struct {
 	ConfigCiliumHubble   ConfigCiliumHubble   `json:"config_cilium_hubble,omitempty" bson:"config_cilium_hubble,omitempty"`
 	ConfigKubeArmorRelay ConfigKubeArmorRelay `json:"config_kubearmor_relay,omitempty" bson:"config_kubearmor_relay,omitempty"`
 
-	ConfigNetPolicy     ConfigNetworkPolicy `json:"config_network_policy,omitempty" bson:"config_network_policy,omitempty"`
-	ConfigSysPolicy     ConfigSystemPolicy  `json:"config_system_policy,omitempty" bson:"config_system_policy,omitempty"`
-	ConfigClusterMgmt   ConfigClusterMgmt   `json:"config_cluster_mgmt,omitempty" bson:"config_cluster_mgmt,omitempty"`
-	ConfigObservability ConfigObservability `json:"config_observability,omitempty" bson:"config_observability,omitempty"`
-	ConfigPublisher     ConfigPublisher     `json:"config_summarizer,omitempty" bson:"config_summarizer,omitempty"`
+	ConfigNetPolicy         ConfigNetworkPolicy     `json:"config_network_policy,omitempty" bson:"config_network_policy,omitempty"`
+	ConfigSysPolicy         ConfigSystemPolicy      `json:"config_system_policy,omitempty" bson:"config_system_policy,omitempty"`
+	ConfigClusterMgmt       ConfigClusterMgmt       `json:"config_cluster_mgmt,omitempty" bson:"config_cluster_mgmt,omitempty"`
+	ConfigObservability     ConfigObservability     `json:"config_observability,omitempty" bson:"config_observability,omitempty"`
+	ConfigPublisher         ConfigPublisher         `json:"config_summarizer,omitempty" bson:"config_summarizer,omitempty"`
+	ConfigPurgeOldDBEntries ConfigPurgeOldDBEntries `json:"config_purge_old_db_entries,omitempty" bson:"config_purge_old_db_entries,omitempty"`
 }


### PR DESCRIPTION
- This PR contains generic config for purge old db entries for specific time. 
- It uses cron job to run the db query.
- discovery-engine currently uses MySQL and SQLite as databases.
- `accuknox-obs.db` and `accuknox-pol.db` added in `local-file.yaml` as of now.