### PR TITLE
Purge Old DB Entries

### DIFF
--- a/src/conf/local-file.yaml
+++ b/src/conf/local-file.yaml
@@ -44,6 +44,13 @@ publisher:
   enable: true
   cron-job-time-interval: "0h1m00s"         # format: XhYmZs
 
+purge-old-db-entries:
+  enable: true 
+  cron-job-time-interval: "240h0m00s"      # format: XhYmZs
+  dbname: 
+   - ./accuknox-obs.db
+   - ./accuknox-pol.db
+
 database:
   driver: sqlite3
   host: 127.0.0.1

--- a/src/config/configManager.go
+++ b/src/config/configManager.go
@@ -200,6 +200,13 @@ func LoadConfigFromFile() {
 		CronJobTimeInterval: "@every " + viper.GetString("publisher.cron-job-time-interval"),
 	}
 
+	// for purge old entries from db
+	CurrentCfg.ConfigPurgeOldDBEntries = types.ConfigPurgeOldDBEntries{
+		Enable:              viper.GetBool("purge-old-db-entries.enable"),
+		CronJobTimeInterval: "@every " + viper.GetString("purge-old-db-entries.cron-job-time-interval"),
+		DBName:              viper.GetStringSlice("purge-old-db-entries.dbname"),
+	}
+
 	// load database
 	CurrentCfg.ConfigDB = LoadConfigDB()
 
@@ -465,4 +472,20 @@ func GetCfgPublisherEnable() bool {
 
 func GetCfgPublisherCronJobTime() string {
 	return CurrentCfg.ConfigPublisher.CronJobTimeInterval
+}
+
+// ========================== //
+// == Purge Old DB Entries == //
+// ========================== //
+
+func GetCfgPurgeOldDBEntriesEnable() bool {
+	return CurrentCfg.ConfigPurgeOldDBEntries.Enable
+}
+
+func GetCfgPurgeOldDBEntriesCronJobTime() string {
+	return CurrentCfg.ConfigPurgeOldDBEntries.CronJobTimeInterval
+}
+
+func GetCfgPurgeOldDBEntriesDBName() []string {
+	return CurrentCfg.ConfigPurgeOldDBEntries.DBName
 }

--- a/src/libs/dbHandler.go
+++ b/src/libs/dbHandler.go
@@ -4,7 +4,10 @@ import (
 	"database/sql"
 	"errors"
 
+	cfg "github.com/accuknox/auto-policy-discovery/src/config"
+	logger "github.com/accuknox/auto-policy-discovery/src/logging"
 	"github.com/accuknox/auto-policy-discovery/src/types"
+	"github.com/robfig/cron"
 )
 
 // ================= //
@@ -615,4 +618,39 @@ func getSysSummarySQL(db *sql.DB, dbName string, filterOptions types.SystemSumma
 	}
 
 	return resSummary, err
+}
+
+// ==================================== //
+// == Purge Old DB Entries Cron Job ==  //
+// ==================================== //
+var (
+	CfgDB          types.ConfigDB
+	PurgeDBCronJob *cron.Cron
+	PurgeDBMap     types.ConfigPurgeOldDBEntries
+)
+
+func InitPurgeOldDBEntries() {
+	log = logger.GetInstance()
+	CfgDB = cfg.GetCfgDB()
+
+	if cfg.GetCfgPurgeOldDBEntriesEnable() {
+
+		PurgeDBCronJob = cron.New()
+		err := PurgeDBCronJob.AddFunc(cfg.GetCfgPurgeOldDBEntriesCronJobTime(), PurgeOldDBEntriesCronJob) // time interval
+		if err != nil {
+			log.Error().Msg(err.Error())
+			return
+		}
+		PurgeDBCronJob.Start()
+		log.Info().Msg("Purging Old DB Entries cron job started")
+	}
+}
+
+// Checking which type of Database
+func PurgeOldDBEntriesCronJob() {
+	if cfg.CurrentCfg.ConfigDB.DBDriver == "mysql" {
+		PurgeOldDBEntriesMySQL(types.ConfigDB{})
+	} else if cfg.CurrentCfg.ConfigDB.DBDriver == "sqlite3" {
+		PurgeOldDBEntriesSQLite(types.ConfigDB{})
+	}
 }

--- a/src/libs/mysqlHandler.go
+++ b/src/libs/mysqlHandler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/accuknox/auto-policy-discovery/src/config"
 	"github.com/accuknox/auto-policy-discovery/src/types"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -1723,4 +1724,25 @@ func GetSystemSummaryMySQL(cfg types.ConfigDB, filterOptions types.SystemSummary
 	res, err := getSysSummarySQL(db, TableSystemSummarySQLite, filterOptions)
 
 	return res, err
+}
+
+// ========================== //
+// == Purge Old DB Entries == //
+// ========================== //
+
+func PurgeOldDBEntriesMySQL(cfg types.ConfigDB) {
+	db := connectMySQL(cfg)
+	defer db.Close()
+
+	timeNow := (ConvertStrToUnixTime("now"))
+	purgeTime := (config.GetCfgPublisherCronJobTime()) //sec
+	PurgeTimeValue, err := strconv.ParseInt(purgeTime, 10, 64)
+	if err != nil {
+		log.Error().Msg(err.Error())
+	}
+	ConvertedValue := timeNow - PurgeTimeValue
+	query := "DELETE FROM system_summary WHERE updated_time < " + strconv.Itoa(int(ConvertedValue))
+	if _, err := db.Query(query); err != nil {
+		log.Error().Msg(err.Error())
+	}
 }

--- a/src/libs/sqliteHandler.go
+++ b/src/libs/sqliteHandler.go
@@ -1728,3 +1728,24 @@ func GetSystemSummarySQLite(cfg types.ConfigDB, filterOptions types.SystemSummar
 
 	return res, err
 }
+
+// ========================== //
+// == Purge Old DB Entries == //
+// ========================== //
+func PurgeOldDBEntriesSQLite(cfg types.ConfigDB) {
+	db := connectSQLite(cfg, cfg.SQLiteDBPath)
+	defer db.Close()
+
+	timeNow := (ConvertStrToUnixTime("now"))
+	purgeTime := (config.GetCfgPublisherCronJobTime()) //sec
+	PurgeTimeValue, err := strconv.ParseInt(purgeTime, 10, 64)
+	if err != nil {
+		log.Error().Msg(err.Error())
+	}
+	// Running DB Query
+	ConvertedValue := timeNow - PurgeTimeValue
+	query := "DELETE FROM system_summary WHERE updated_time < " + strconv.Itoa(int(ConvertedValue))
+	if _, err := db.Query(query); err != nil {
+		log.Error().Msg(err.Error())
+	}
+}

--- a/src/types/configData.go
+++ b/src/types/configData.go
@@ -110,6 +110,12 @@ type ConfigPublisher struct {
 	CronJobTimeInterval string `json:"cronjob_time_interval,omitempty" bson:"cronjob_time_interval,omitempty"`
 }
 
+type ConfigPurgeOldDBEntries struct {
+	Enable              bool     `json:"enable,omitempty" bson:"enable,omiempty"`
+	CronJobTimeInterval string   `json:"cronjob_time_interval,omitempty" bson:"cronjob_time_interval,omitempty"`
+	DBName              []string `json:"db_name,omitempty" bson:"db_name,omitempty"`
+}
+
 type Configuration struct {
 	ConfigName string `json:"config_name,omitempty" bson:"config_name,omitempty"`
 	Status     int    `json:"status,omitempty" bson:"status,omitempty"`
@@ -122,9 +128,10 @@ type Configuration struct {
 	ConfigCiliumHubble   ConfigCiliumHubble   `json:"config_cilium_hubble,omitempty" bson:"config_cilium_hubble,omitempty"`
 	ConfigKubeArmorRelay ConfigKubeArmorRelay `json:"config_kubearmor_relay,omitempty" bson:"config_kubearmor_relay,omitempty"`
 
-	ConfigNetPolicy     ConfigNetworkPolicy `json:"config_network_policy,omitempty" bson:"config_network_policy,omitempty"`
-	ConfigSysPolicy     ConfigSystemPolicy  `json:"config_system_policy,omitempty" bson:"config_system_policy,omitempty"`
-	ConfigClusterMgmt   ConfigClusterMgmt   `json:"config_cluster_mgmt,omitempty" bson:"config_cluster_mgmt,omitempty"`
-	ConfigObservability ConfigObservability `json:"config_observability,omitempty" bson:"config_observability,omitempty"`
-	ConfigPublisher     ConfigPublisher     `json:"config_summarizer,omitempty" bson:"config_summarizer,omitempty"`
+	ConfigNetPolicy         ConfigNetworkPolicy     `json:"config_network_policy,omitempty" bson:"config_network_policy,omitempty"`
+	ConfigSysPolicy         ConfigSystemPolicy      `json:"config_system_policy,omitempty" bson:"config_system_policy,omitempty"`
+	ConfigClusterMgmt       ConfigClusterMgmt       `json:"config_cluster_mgmt,omitempty" bson:"config_cluster_mgmt,omitempty"`
+	ConfigObservability     ConfigObservability     `json:"config_observability,omitempty" bson:"config_observability,omitempty"`
+	ConfigPublisher         ConfigPublisher         `json:"config_summarizer,omitempty" bson:"config_summarizer,omitempty"`
+	ConfigPurgeOldDBEntries ConfigPurgeOldDBEntries `json:"config_purge_old_db_entries,omitempty" bson:"config_purge_old_db_entries,omitempty"`
 }


### PR DESCRIPTION
• This PR contains generic config for purge old db entries for specific time.
• It uses cron job to run the db query.
• discovery-engine currently uses MySQL and SQLite as databases.
• accuknox-obs.db and accuknox-pol.db added in local-file.yaml as of now.