### PR TITLE
Policy name randomizer for network-policy

### DIFF
--- a/src/common/common.go
+++ b/src/common/common.go
@@ -2,10 +2,11 @@ package common
 
 import (
 	"fmt"
+	"hash/fnv"
 	"strings"
 )
 
-//Basic Constant
+// Basic Constant
 const (
 	STATUS     = "Passed"
 	LIMIT      = " limit "
@@ -22,7 +23,7 @@ const (
 	L3_L4      = "L3_L4"
 )
 
-//Query Constant
+// Query Constant
 const (
 	WHERE_NAMESPACE_NAME  = ` where namespace_name = "`
 	WHERE                 = ` where `
@@ -33,14 +34,14 @@ const (
 	ORDER_BY_UPDATED_TIME = ` order by updated_time DESC`
 )
 
-//Error Constant
+// Error Constant
 const (
 	INCORRECT_DIRECTION = "incorrect direction"
 	INCORRECT_VERDICT   = "incorrect verdict"
 	INCORRECT_TYPE      = "incorrect type"
 )
 
-//ConvertArrayToString - Convert Array of string to String
+// ConvertArrayToString - Convert Array of string to String
 func ConvertArrayToString(arr []string) string {
 	var str string
 	for _, label := range arr {
@@ -58,7 +59,7 @@ func ConvertArrayToString(arr []string) string {
 
 }
 
-//ConvertStringToArray - Convert String to Array of string
+// ConvertStringToArray - Convert String to Array of string
 func ConvertStringToArray(str string) []string {
 	return strings.Split(str, ",")
 }
@@ -85,4 +86,10 @@ func StringDeDuplication(strSlice []string) []string {
 		}
 	}
 	return list
+}
+
+func HashInt(s string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum32()
 }

--- a/src/networkpolicy/deduplicator.go
+++ b/src/networkpolicy/deduplicator.go
@@ -1,8 +1,10 @@
 package networkpolicy
 
 import (
+	"strconv"
 	"strings"
 
+	"github.com/accuknox/auto-policy-discovery/src/common"
 	"github.com/accuknox/auto-policy-discovery/src/libs"
 	types "github.com/accuknox/auto-policy-discovery/src/types"
 
@@ -761,19 +763,12 @@ func existPolicyName(policyNamesMap map[string]bool, name string) bool {
 }
 
 func GeneratePolicyName(policyNamesMap map[string]bool, policy types.KnoxNetworkPolicy, clusterName string) types.KnoxNetworkPolicy {
-	egressPrefix := "autopol-egress-"
-	ingressPrefix := "autopol-ingress-"
-
 	polType := policy.Metadata["type"]
-	name := "autopol-" + polType + "-" + libs.RandSeq(15)
 
-	for existPolicyName(policyNamesMap, name) {
-		if polType == "egress" {
-			name = egressPrefix + libs.RandSeq(15)
-		} else {
-			name = ingressPrefix + libs.RandSeq(15)
-		}
-	}
+	randomizer := strconv.FormatUint(uint64(common.HashInt(polType+policy.Metadata["labels"]+
+		policy.Metadata["namespace"]+policy.Metadata["clustername"]+policy.Metadata["containername"])), 10)
+
+	name := "autopol-" + polType + "-" + randomizer
 
 	policyNamesMap[name] = true
 

--- a/src/networkpolicy/deduplicator.go
+++ b/src/networkpolicy/deduplicator.go
@@ -765,10 +765,9 @@ func existPolicyName(policyNamesMap map[string]bool, name string) bool {
 func GeneratePolicyName(policyNamesMap map[string]bool, policy types.KnoxNetworkPolicy, clusterName string) types.KnoxNetworkPolicy {
 	polType := policy.Metadata["type"]
 
-	randomizer := strconv.FormatUint(uint64(common.HashInt(polType+policy.Metadata["labels"]+
-		policy.Metadata["namespace"]+policy.Metadata["clustername"]+policy.Metadata["containername"])), 10)
-
-	name := "autopol-" + polType + "-" + randomizer
+	hashInt := common.HashInt(polType+policy.Metadata["labels"]+policy.Metadata["namespace"]+policy.Metadata["clustername"]+policy.Metadata["containername"])
+	hash := strconv.FormatUint(uint64(hashInt), 10)
+	name := "autopol-" + polType + "-" + hash
 
 	policyNamesMap[name] = true
 

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -2,7 +2,6 @@ package systempolicy
 
 import (
 	"errors"
-	"hash/fnv"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -771,16 +770,12 @@ func mergeFromSource(pols []types.KnoxSystemPolicy) []types.KnoxSystemPolicy {
 	return results
 }
 
-func hashInt(s string) uint32 {
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(s))
-	return h.Sum32()
-}
-
 func mergeSysPolicies(pols []types.KnoxSystemPolicy) []types.KnoxSystemPolicy {
 	var results []types.KnoxSystemPolicy
 	for _, pol := range pols {
-		pol.Metadata["name"] = "autopol-system-" + strconv.FormatUint(uint64(hashInt(pol.Metadata["labels"]+pol.Metadata["namespace"]+pol.Metadata["clustername"]+pol.Metadata["containername"])), 10)
+		pol.Metadata["name"] = "autopol-system-" +
+			strconv.FormatUint(uint64(common.HashInt(pol.Metadata["labels"]+
+				pol.Metadata["namespace"]+pol.Metadata["clustername"]+pol.Metadata["containername"])), 10)
 		i := checkIfMetadataMatches(pol, results)
 		if i < 0 {
 			results = append(results, pol)


### PR DESCRIPTION
Problem Statement
===============
Discovery-engine discovers both system and network. For system policies, the policy name is created based on hash of certain policy fields which are unique. Hence on multiple reboots/restarts of DE, the policy name remains the same. 

In case of network policy, the name is based on randomizer. Which is causing the duplicate policies being written to policy_yaml in SaaS's DB. 

Solution
======
Adding hash based naming mechanism similar to system policy resolves this issue.

PR
==
This PR contains the randomization based on unique fields of a policy.

Signed-off-by: Eswar Rajan Subramanian [eswar@accuknox.com](mailto:eswar@accuknox.com)