### PR TITLE
enhancement(recommend): harden policy consolidation

### DIFF
--- a/src/conf/local-file.yaml
+++ b/src/conf/local-file.yaml
@@ -119,3 +119,4 @@ recommend:
   operation-mode: 1                       # 1: cronjob | 2: one-time-job
   cron-job-time-interval: "1h0m00s"       # format: XhYmZs
   recommend-host-policy: true
+  merge-policy: false                    # merging harden policies

--- a/src/conf/local.yaml
+++ b/src/conf/local.yaml
@@ -71,3 +71,4 @@ recommend:
   operation-mode: 1                       # 1: cronjob | 2: one-time-job
   cron-job-time-interval: "1h0m00s"       # format: XhYmZs
   recommend-host-policy: true
+  merge-policy: false                     # merging harden policies

--- a/src/config/configManager.go
+++ b/src/config/configManager.go
@@ -212,6 +212,7 @@ func LoadConfigFromFile() {
 		OneTimeJobTimeSelection: "", // e.g., 2021-01-20 07:00:23|2021-01-20 07:00:25
 		OperationMode:           viper.GetInt("recommend.operation-mode"),
 		RecommendHostPolicy:     viper.GetBool("recommend.recommend-host-policy"),
+		MergePolicy:             viper.GetBool("recommend.merge-policy"),
 	}
 
 	// load database
@@ -515,4 +516,8 @@ func GetCfgRecOneTime() string {
 
 func GetCfgRecommendHostPolicy() bool {
 	return CurrentCfg.ConfigRecommendPolicy.RecommendHostPolicy
+}
+
+func GetCfgMergePolicy() bool {
+	return CurrentCfg.ConfigRecommendPolicy.MergePolicy
 }

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -851,6 +851,11 @@ func mergeSysPolicies(pols []types.KnoxSystemPolicy) []types.KnoxSystemPolicy {
 	return results
 }
 
+// Wrapper function for mergeSysPolicies
+func MergeSysPolicies(pols []types.KnoxSystemPolicy) []types.KnoxSystemPolicy {
+	return mergeSysPolicies(pols)
+}
+
 func ConvertWPFSToKnoxSysPolicy(wpfsSet types.ResourceSetMap, pnMap types.PolicyNameMap) []types.KnoxSystemPolicy {
 	var results []types.KnoxSystemPolicy
 	for wpfs, fsset := range wpfsSet {

--- a/src/types/configData.go
+++ b/src/types/configData.go
@@ -121,6 +121,7 @@ type ConfigRecommendPolicy struct {
 	CronJobTimeInterval     string `json:"cronjob_time_interval,omitempty" bson:"cronjob_time_interval,omitempty"`
 	OneTimeJobTimeSelection string `json:"one_time_job_time_selection,omitempty" bson:"one_time_job_time_selection,omitempty"`
 	RecommendHostPolicy     bool   `json:"recommend_host_policy,omitempty" bson:"recommend_host_policy,omitempty"`
+	MergePolicy             bool   `json:"merge_policy,omitempty" bson:"merge_policy,omitempty"`
 }
 
 type Configuration struct {

--- a/src/types/constants.go
+++ b/src/types/constants.go
@@ -36,7 +36,8 @@ const (
 	PolicyTypeNetwork = "network"
 
 	// Hardening policy
-	HardeningPolicy = "harden"
+	HardeningPolicy      = "harden"
+	HardeningMergePolicy = "harden-merge"
 
 	// Binary Name Filters
 	FilterBinaryKnoxAutoPolicy = "knoxAutoPolicy"

--- a/src/types/policyData.go
+++ b/src/types/policyData.go
@@ -242,6 +242,11 @@ type KnoxMatchPaths struct {
 	ReadOnly   bool             `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
 	OwnerOnly  bool             `json:"ownerOnly,omitempty" yaml:"ownerOnly,omitempty"`
 	FromSource []KnoxFromSource `json:"fromSource,omitempty" yaml:"fromSource,omitempty"`
+
+	Action   string   `json:"action,omitempty" yaml:"action,omitempty"`
+	Severity int      `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Message  string   `json:"message,omitempty" yaml:"message,omitempty"`
+	Tags     []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 // KnoxMatchDirectories Structure
@@ -251,6 +256,11 @@ type KnoxMatchDirectories struct {
 	ReadOnly   bool             `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
 	OwnerOnly  bool             `json:"ownerOnly,omitempty" yaml:"ownerOnly,omitempty"`
 	FromSource []KnoxFromSource `json:"fromSource,omitempty" yaml:"fromSource,omitempty"`
+
+	Action   string   `json:"action,omitempty" yaml:"action,omitempty"`
+	Severity int      `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Message  string   `json:"message,omitempty" yaml:"message,omitempty"`
+	Tags     []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 // KnoxMatchProtocols Structure


### PR DESCRIPTION
## Enhancement
This PR contains enhancement for enhancement for karmor recommend:

Previously we are getting lots of recommended policies for workloads and to simply that this PR added merge functionality to consolidate recommended policy into single policy that you can apply for each workload.

This is the structure of the consolidated policy:
```yaml
apiVersion: security.kubearmor.com/v1
kind: KubeArmorPolicy
metadata: 
  name: ksp-hardening-policies
  namespace: default
spec:
  selector: 
    matchLabels: 
      app: app
  file:
    matchPaths:
    - path:
      readOnly:
      action:
      severity:
      message:
      tags:
    matchDirectories:
    - dir: 
      recursive: 
      readOnly: 
      action: 
      severity: 
      message: 
      tags: 
  process:
    matchPaths:
    - path:
      readOnly:
      action:
      severity:
      message:
      tags:
    matchDirectories:
    - dir:
      recursive:
      readOnly:
      action:
      severity:
      message:
      tags:
```

