### PR TITLE
fix data race conditions

### DIFF
--- a/src/observability/kubearmor.go
+++ b/src/observability/kubearmor.go
@@ -68,14 +68,15 @@ func clearKubeArmorLogMap() {
 }
 
 func ProcessSystemLogs() {
-	if len(SystemLogs) <= 0 {
-		return
-	}
 
 	SystemLogsMutex.Lock()
 	locSysLogs := SystemLogs
 	SystemLogs = []*pb.Alert{} //reset
 	SystemLogsMutex.Unlock()
+
+	if len(locSysLogs) <= 0 {
+		return
+	}
 
 	ObsMutex.Lock()
 	defer ObsMutex.Unlock()


### PR DESCRIPTION
Added mutex locks to prevent race conditions #685 

Race condition error:
```
WARNING: DATA RACE
Read at 0x0000042a0ff0 by goroutine 304:
  github.com/accuknox/auto-policy-discovery/src/observability.ProcessSystemLogs()
      /home/knownymous/go/src/github.com/auto-policy-discovery/src/observability/kubearmor.go:71 +0x49
  github.com/accuknox/auto-policy-discovery/src/observability.ObservabilityCronJob()
      /home/knownymous/go/src/github.com/auto-policy-discovery/src/observability/observability.go:103 +0x37
  github.com/robfig/cron.FuncJob.Run()
      /home/knownymous/go/pkg/mod/github.com/robfig/cron@v1.2.0/cron.go:92 +0x2e
  github.com/robfig/cron.(*Cron).runWithRecovery()
      /home/knownymous/go/pkg/mod/github.com/robfig/cron@v1.2.0/cron.go:165 +0x7b
  github.com/robfig/cron.(*Cron).run.func1()
      /home/knownymous/go/pkg/mod/github.com/robfig/cron@v1.2.0/cron.go:199 +0x58

Previous write at 0x0000042a0ff0 by goroutine 44:
  github.com/accuknox/auto-policy-discovery/src/observability.ProcessKubearmorLogs()
      /home/knownymous/go/src/github.com/auto-policy-discovery/src/observability/kubearmor.go:157 +0xe4
  github.com/accuknox/auto-policy-discovery/src/plugin.StartKubeArmorRelay.func1()
      /home/knownymous/go/src/github.com/auto-policy-discovery/src/plugin/kubearmor.go:468 +0xd1e
  github.com/accuknox/auto-policy-discovery/src/plugin.StartKubeArmorRelay.func3()
      /home/knownymous/go/src/github.com/auto-policy-discovery/src/plugin/kubearmor.go:478 +0x58
```