### PR TITLE
Forming HashInt for naming network-policy

### DIFF
--- a/src/networkpolicy/deduplicator.go
+++ b/src/networkpolicy/deduplicator.go
@@ -1,6 +1,7 @@
 package networkpolicy
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
@@ -764,8 +765,14 @@ func existPolicyName(policyNamesMap map[string]bool, name string) bool {
 
 func GeneratePolicyName(policyNamesMap map[string]bool, policy types.KnoxNetworkPolicy, clusterName string) types.KnoxNetworkPolicy {
 	polType := policy.Metadata["type"]
+	labels := []string{}
 
-	hashInt := common.HashInt(polType+policy.Metadata["labels"]+policy.Metadata["namespace"]+policy.Metadata["clustername"]+policy.Metadata["containername"])
+	for k, v := range policy.Spec.Selector.MatchLabels {
+		labels = append(labels, k+"="+v)
+	}
+	sort.Strings(labels) // sort labels
+
+	hashInt := common.HashInt(polType + strings.Join(labels, ",") + policy.Metadata["namespace"] + clusterName + policy.Metadata["container_name"])
 	hash := strconv.FormatUint(uint64(hashInt), 10)
 	name := "autopol-" + polType + "-" + hash
 

--- a/src/networkpolicy/deduplicator.go
+++ b/src/networkpolicy/deduplicator.go
@@ -772,7 +772,7 @@ func GeneratePolicyName(policyNamesMap map[string]bool, policy types.KnoxNetwork
 	}
 	sort.Strings(labels) // sort labels
 
-	hashInt := common.HashInt(polType + strings.Join(labels, ",") + policy.Metadata["namespace"] + clusterName + policy.Metadata["container_name"])
+	hashInt := common.HashInt(polType + strings.Join(labels, ",") + policy.Metadata["namespace"] + clusterName)
 	hash := strconv.FormatUint(uint64(hashInt), 10)
 	name := "autopol-" + polType + "-" + hash
 

--- a/src/networkpolicy/networkPolicy.go
+++ b/src/networkpolicy/networkPolicy.go
@@ -1893,6 +1893,7 @@ func convertKnoxNetworkLogToKnoxNetworkPolicy(log *types.KnoxNetworkLog, pods []
 
 			iPolicy.Spec.Ingress = append(iPolicy.Spec.Ingress, ingress)
 			iPolicy.Metadata["namespace"] = log.DstNamespace
+			iPolicy.Metadata["container_name"] = log.ContainerName
 
 			ingressPolicy = &iPolicy
 		}
@@ -1910,7 +1911,7 @@ func convertKnoxNetworkLogToKnoxNetworkPolicy(log *types.KnoxNetworkLog, pods []
 		dstEntity := getEntityFromReservedLabels(log.DstReservedLabels)
 		if dstEntity != "" {
 			if dstEntity == "world" && log.DNSQuery != "" {
-				fqdn := types.SpecFQDN{[]string{log.DNSQuery}}
+				fqdn := types.SpecFQDN{MatchNames: []string{log.DNSQuery}}
 				egress.ToFQDNs = append(egress.ToFQDNs, fqdn)
 			} else {
 				egress.ToEntities = append(egress.ToEntities, dstEntity)
@@ -1935,6 +1936,7 @@ func convertKnoxNetworkLogToKnoxNetworkPolicy(log *types.KnoxNetworkLog, pods []
 
 			ePolicy.Spec.Egress = append(ePolicy.Spec.Egress, egress)
 			ePolicy.Metadata["namespace"] = log.SrcNamespace
+			ePolicy.Metadata["container_name"] = log.ContainerName
 			egressPolicy = &ePolicy
 		}
 	} else if log.DstPodName == "" && len(log.DstReservedLabels) == 0 {
@@ -1947,6 +1949,7 @@ func convertKnoxNetworkLogToKnoxNetworkPolicy(log *types.KnoxNetworkLog, pods []
 		// Update namespace
 		if iePolicy.Metadata["status"] == "latest" {
 			iePolicy.Metadata["namespace"] = log.SrcNamespace
+			iePolicy.Metadata["container_name"] = log.ContainerName
 		}
 	}
 

--- a/src/plugin/kubearmor.go
+++ b/src/plugin/kubearmor.go
@@ -430,7 +430,6 @@ func StartKubeArmorRelay(StopChan chan struct{}, cfg types.ConfigKubeArmorRelay)
 				}
 
 				if len(res.Resource) != 0 && res.Operation != "Network" && !strings.HasPrefix(res.Resource, "/") {
-					log.Warn().Msgf("Relative path found: %v", res)
 					continue
 				}
 
@@ -513,7 +512,6 @@ func StartKubeArmorRelay(StopChan chan struct{}, cfg types.ConfigKubeArmorRelay)
 				}
 
 				if len(res.Resource) != 0 && res.Operation != "Network" && !strings.HasPrefix(res.Resource, "/") {
-					log.Warn().Msgf("Relative path found: %v", res)
 					continue
 				}
 
@@ -589,6 +587,7 @@ func ConvertKubeArmorNetLogToKnoxNetLog(kaNwLogs []*pb.Alert) []types.KnoxNetwor
 		var ip, port string
 		locKnoxLog := types.KnoxNetworkLog{
 			ClusterName:       kalog.ClusterName,
+			ContainerName:     kalog.ContainerName,
 			SrcNamespace:      kalog.NamespaceName,
 			SrcReservedLabels: strings.Split(kalog.Labels, ","),
 			SrcPodName:        kalog.PodName,

--- a/src/types/logData.go
+++ b/src/types/logData.go
@@ -4,7 +4,8 @@ package types
 type KnoxNetworkLog struct {
 	FlowID int `json:"flow_id,omitempty" bson:"flow_id"`
 
-	ClusterName string `json:"cluster_name,omitempty" bson:"cluster_name"`
+	ClusterName   string `json:"cluster_name,omitempty" bson:"cluster_name"`
+	ContainerName string `json:"container_name,omitempty" bson:"container_name"`
 
 	SrcNamespace      string   `json:"src_namespace,omitempty" bson:"src_namespace"`
 	SrcReservedLabels []string `json:"src_reserved_labels,omitempty" bson:"src_reserved_labels"`


### PR DESCRIPTION
In addition to the PR, these changes are required to generate fields/data for hashing name for network policy
Without these changes the name of generated policies are duplicate.

Signed-off-by: Eswar Rajan Subramanian [eswar@accuknox.com](mailto:eswar@accuknox.com)