### PR TITLE
fix(summary): exclude `container_id` from `system_summary` table

### DIFF
--- a/src/libs/dbHandler.go
+++ b/src/libs/dbHandler.go
@@ -3,6 +3,8 @@ package libs
 import (
 	"database/sql"
 	"errors"
+	"sort"
+	"strings"
 
 	cfg "github.com/accuknox/auto-policy-discovery/src/config"
 	logger "github.com/accuknox/auto-policy-discovery/src/logging"
@@ -425,8 +427,13 @@ func UpsertSystemSummary(cfg types.ConfigDB, summaryMap map[types.SystemSummary]
 }
 
 func upsertSysSummarySQL(db *sql.DB, summary types.SystemSummary, timeCount types.SysSummaryTimeCount) error {
+	// sorts pod labels upon pod restart
+	sortedLabels := strings.Split(summary.Labels, ",")
+	sort.Strings(sortedLabels)
+	summary.Labels = strings.Join(sortedLabels, ",")
+
 	queryString := `cluster_name = ? and cluster_id = ? and workspace_id = ? and namespace_name = ? and namespace_id = ? and container_name = ? and container_image = ? 
-					and container_id = ? and podname = ? and operation = ? and labels = ? and deployment_name = ? and source = ? and destination = ? 
+					and podname = ? and operation = ? and labels = ? and deployment_name = ? and source = ? and destination = ? 
 					and destination_namespace = ? and destination_labels = ? and type = ? and ip = ? and port = ? and protocol = ? and action = ? and bindport = ? and bindaddr = ?`
 
 	query := "UPDATE " + TableSystemSummarySQLite + " SET count=count+?, updated_time=? WHERE " + queryString + " "
@@ -447,7 +454,6 @@ func upsertSysSummarySQL(db *sql.DB, summary types.SystemSummary, timeCount type
 		summary.NamespaceId,
 		summary.ContainerName,
 		summary.ContainerImage,
-		summary.ContainerID,
 		summary.PodName,
 		summary.Operation,
 		summary.Labels,


### PR DESCRIPTION
## Issue:
Repeated entries in `system_summary `table due to different `container_id` when pod restarts.

## Description:
Every time a pod restarts, it creates a new `container_id.` This results in repeated entries in the `system_summary` table for the same pod and container, causing issues with data analysis when we are using karmor summary in CLI.

## Fix:
To prevent repeated entries in the `system_summary` table, this PR exclude the `container_id` field from the `upsertSysSummarySQL` function. Instead, the function will now use the `podname` field to check for existing entries and update them accordingly. This will ensure that only one entry exists in the table for each unique pod, regardless of how many times the container is restarted.