### PR TITLE
fix: Add complete arguments to GetHardenPolicy(..) in recommend test

### DIFF
--- a/tests/go.sum
+++ b/tests/go.sum
@@ -103,8 +103,6 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/accuknox/auto-policy-discovery/src v0.0.0-20230207142942-3e2adb51594b h1:XiqvaZu63u8edBgKIUD69IKwgzY9tPCwm8WmQLrT0W4=
-github.com/accuknox/auto-policy-discovery/src v0.0.0-20230207142942-3e2adb51594b/go.mod h1:PvmbhNMbOH27CbhOTbWy3Vd0Od8B65ixNLd9STvBlP0=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/tests/recommend/recommned_test.go
+++ b/tests/recommend/recommned_test.go
@@ -38,7 +38,13 @@ func GetPolicy() []types.KnoxSystemPolicy {
 		return nil
 	}
 
-	policies := recommendpolicy.GetHardenPolicy(deployments, replicaSets, statefulSets, nsNotFilter)
+	daemonSets, err := client.AppsV1().DaemonSets("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		log.Error().Msg("error getting daemonsets err=" + err.Error())
+		return nil
+	}
+
+	policies := recommendpolicy.GetHardenPolicy(deployments, replicaSets, statefulSets, daemonSets, nsNotFilter)
 
 	return policies
 }


### PR DESCRIPTION
Signed-off-by: Vyom-Yadav [jackhammervyom@gmail.com](mailto:jackhammervyom@gmail.com)

---

Changes:

- The test suite was not compilable as `GetHardenPolicy(..)` wasn't called with enough arguments, added the missing argument.
- `go mod tidy`