### PR TITLE
add support for crown jewel policies

### DIFF
--- a/src/conf/local-file.yaml
+++ b/src/conf/local-file.yaml
@@ -119,8 +119,13 @@ recommend:
   operation-mode: 1                       # 1: cronjob | 2: one-time-job
   cron-job-time-interval: "1h0m00s"       # format: XhYmZs
   recommend-host-policy: true
-  template-version: ""                    # policy template version to be used for recommendation (keep empty to fetches latest)
-  admission-controller-policy: false
+  template-version: "v0.2.2"              # policy template version to be used for recommendation (keep empty to fetches latest)
+
+# Recommended policies configuration
+crownjewel:
+  operation-mode: 1                       # 1: cronjob | 2: one-time-job
+  cron-job-time-interval: "0h0m20s"       # format: XhYmZs
+
 # license
 license:
   enabled: false

--- a/src/conf/local.yaml
+++ b/src/conf/local.yaml
@@ -86,6 +86,11 @@ recommend:
   template-version: ""
   admission-controller-policy: false
 
+# Recommended policies configuration
+crownjewel:
+  operation-mode: 1                       # 1: cronjob | 2: one-time-job
+  cron-job-time-interval: "1h0m00s"       # format: XhYmZs
+
 # license
 license:
   enabled: false

--- a/src/config/configManager.go
+++ b/src/config/configManager.go
@@ -219,6 +219,13 @@ func LoadConfigFromFile() {
 		RecommendTemplateVersion:           viper.GetString("recommend.template-version"),
 	}
 
+	// crown jewel policy configurations
+	CurrentCfg.ConfigCrownjewelPolicy = types.ConfigCrownjewelPolicy{
+		CronJobTimeInterval:     "@every " + viper.GetString("crownjewel.cron-job-time-interval"),
+		OneTimeJobTimeSelection: "", // e.g., 2021-01-20 07:00:23|2021-01-20 07:00:25
+		OperationMode:           viper.GetInt("crownjewel.operation-mode"),
+	}
+
 	// load database
 	CurrentCfg.ConfigDB = LoadConfigDB()
 
@@ -531,6 +538,25 @@ func GetCfgRecommendHostPolicy() bool {
 
 func GetCfgRecommendAdmissionControllerPolicy() bool {
 	return CurrentCfg.ConfigRecommendPolicy.RecommendAdmissionControllerPolicy
+}
+
+// ================================== //
+// == Get Crown Jewel Config Info == //
+// ================================ //
+
+// run the Crown jewel scan once
+func GetCfgCrownjewelOneTime() string {
+	return CurrentCfg.ConfigCrownjewelPolicy.OneTimeJobTimeSelection
+}
+
+// run the Crown jewel scan as a cron job
+func GetCfgCrownjewelCronJobTime() string {
+	return CurrentCfg.ConfigCrownjewelPolicy.CronJobTimeInterval
+}
+
+// dont' run the Crown jewel scan
+func GetCfgCrownjewelOperationMode() int {
+	return CurrentCfg.ConfigCrownjewelPolicy.OperationMode
 }
 
 func GetCfgRecommendTemplateVersion() string {

--- a/src/crownjewel/crownjewel.go
+++ b/src/crownjewel/crownjewel.go
@@ -1,0 +1,392 @@
+package crownjewel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/accuknox/auto-policy-discovery/src/cluster"
+	"github.com/accuknox/auto-policy-discovery/src/common"
+	"github.com/accuknox/auto-policy-discovery/src/config"
+	cfg "github.com/accuknox/auto-policy-discovery/src/config"
+	"github.com/accuknox/auto-policy-discovery/src/libs"
+	logger "github.com/accuknox/auto-policy-discovery/src/logging"
+	obs "github.com/accuknox/auto-policy-discovery/src/observability"
+	opb "github.com/accuknox/auto-policy-discovery/src/protobuf/v1/observability"
+	"github.com/accuknox/auto-policy-discovery/src/systempolicy"
+	"github.com/accuknox/auto-policy-discovery/src/types"
+	"github.com/robfig/cron"
+	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var log *zerolog.Logger
+
+// CrownjewelCronJob for cron job
+var CrownjewelCronJob *cron.Cron
+
+var CrownjewelStopChan chan struct{}
+
+// CrownjewelWorkerStatus global worker
+var CrownjewelWorkerStatus string
+
+// const values
+const (
+	// operation mode
+	opModeNoop    = 0
+	opModeCronjob = 1
+
+	// status
+	statusRunning = "running"
+	statusIdle    = "idle"
+)
+
+// init Function
+func init() {
+	log = logger.GetInstance()
+	CrownjewelWorkerStatus = statusIdle
+	CrownjewelStopChan = make(chan struct{})
+}
+
+// StartCrownjewelWorker starts the crown jewel worker (run once or as a cronjob)
+func StartCrownjewelWorker() {
+	if CrownjewelWorkerStatus != statusIdle {
+		log.Info().Msg("There is no idle Crown jewel policy worker")
+		return
+	}
+	if cfg.GetCfgCrownjewelOperationMode() == opModeNoop { // Do not run the operation
+		log.Info().Msg("Crown jewel operation mode is NOOP... ")
+	} else if cfg.GetCfgCrownjewelOperationMode() == opModeCronjob { // every time intervals
+		log.Info().Msg("Crown jewel policy cron job started")
+		CrownjewelPolicyMain()
+		StartCrownjewelCronJob()
+	} else { // one-time generation
+		CrownjewelPolicyMain()
+		log.Info().Msgf("Crown jewel policy onetime job done")
+	}
+}
+
+// StartCrownjewelCronJob starts the cronjob
+func StartCrownjewelCronJob() {
+	// init cron job
+	CrownjewelCronJob = cron.New()
+	err := CrownjewelCronJob.AddFunc(cfg.GetCfgCrownjewelCronJobTime(), CrownjewelPolicyMain)
+	if err != nil {
+		log.Error().Msg(err.Error())
+		return
+	}
+	CrownjewelCronJob.Start()
+}
+
+// StopCrownjewelCronJob stops the cronjob
+func StopCrownjewelCronJob() {
+	if CrownjewelCronJob != nil {
+		log.Info().Msg("Got a signal to terminate the auto system policy discovery")
+
+		CrownjewelStopChan = make(chan struct{})
+
+		close(CrownjewelStopChan)
+
+		CrownjewelCronJob.Stop() // Stop the scheduler (does not stop any jobs already running).
+
+		CrownjewelCronJob = nil
+	}
+}
+
+// Create Crown Jewel Policy based on K8s object type
+func CrownjewelPolicyMain() {
+	deployment := cluster.GetDeploymentsFromK8sClient()
+	client := cluster.ConnectK8sClient()
+
+	for _, d := range deployment {
+		err := getFilteredPolicy(client, d.Name, d.Namespace, d.Labels)
+		if err != nil {
+			log.Error().Msg("Error getting mount paths, err=" + err.Error())
+		}
+	}
+}
+
+type LabelMap = map[string]string
+
+// Get list of running processes from observability data
+func getProcessList(client kubernetes.Interface, namespace string, labels string) ([]string, error) {
+	var processList []string
+	duplicatePaths := make(map[string]bool)
+
+	podList, err := client.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
+	if err != nil {
+		log.Warn().Msg(err.Error())
+	}
+	for _, pod := range podList.Items {
+		for _, container := range pod.Spec.Containers {
+			sumResp, err := obs.GetSummaryData(&opb.Request{
+				PodName:       pod.Name,
+				NameSpace:     pod.Namespace,
+				ContainerName: container.Name,
+				Type:          "process,file",
+			})
+			if err != nil {
+				log.Warn().Msgf("Error getting summary data for pod %s, container %s, namespace %s: %s", pod.Name, container.Name, pod.Namespace, err.Error())
+				break
+			}
+
+			for _, fileData := range sumResp.FileData {
+				if !duplicatePaths[fileData.Source] {
+					// ignore serviceaccount related process
+					if strings.Contains(fileData.Destination, "serviceaccount") {
+						continue
+					}
+					processList = append(processList, fileData.Source)
+					duplicatePaths[fileData.Source] = true
+				}
+			}
+		}
+	}
+	return processList, nil
+}
+
+// Get all mounted paths
+func getVolumeMountPaths(client kubernetes.Interface, labels string) ([]string, error) {
+	podList, err := client.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pod list: %v", err)
+	}
+
+	var mountPaths []string
+
+	for _, pod := range podList.Items {
+		for _, container := range pod.Spec.Containers {
+			for _, volumeMount := range container.VolumeMounts {
+				mountPaths = append(mountPaths, volumeMount.MountPath)
+			}
+		}
+	}
+	return mountPaths, nil
+}
+
+// Get used mount paths from observability data
+func usedMountPath(client kubernetes.Interface, namespace string, labels string) ([]string, map[string]string, error) {
+	var sumResponses []string
+	fromSource := make(map[string]string)
+
+	podList, err := client.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
+	if err != nil {
+		log.Warn().Msg(err.Error())
+	}
+
+	for _, pod := range podList.Items {
+		for _, container := range pod.Spec.Containers {
+			sumResp, err := obs.GetSummaryData(&opb.Request{
+				PodName:       pod.Name,
+				NameSpace:     pod.Namespace,
+				ContainerName: container.Name,
+				Type:          "process,file",
+			})
+			if err != nil {
+				log.Warn().Msgf("Error getting summary data for pod %s, container %s, namespace %s: %s", pod.Name, container.Name, pod.Namespace, err.Error())
+				break
+			}
+
+			for _, fileData := range sumResp.FileData {
+				sumResponses = append(sumResponses, fileData.Destination)
+				fromSource[fileData.Destination] = fileData.Source
+			}
+		}
+	}
+	return sumResponses, fromSource, nil
+}
+
+// Match used mounts paths with actually accessed mount paths
+func accessedMountPaths(sumResp, mnt []string) ([]string, error) {
+	var matchedMountPaths []string
+	duplicatePaths := make(map[string]bool)
+
+	for _, sumRespPath := range sumResp {
+		for _, mntPath := range mnt {
+			if strings.HasPrefix(sumRespPath, mntPath) && !duplicatePaths[mntPath] {
+				matchedMountPaths = append(matchedMountPaths, mntPath)
+				duplicatePaths[mntPath] = true
+			}
+		}
+	}
+	return matchedMountPaths, nil
+}
+
+// Ignore namespaces based on config
+func getFilteredPolicy(client kubernetes.Interface, cname, namespace string, labels string) error {
+	// filters to check the namespaces to be ignored
+	nsFilter := config.CurrentCfg.ConfigSysPolicy.NsFilter
+	nsNotFilter := config.CurrentCfg.ConfigSysPolicy.NsNotFilter
+
+	var policies []types.KnoxSystemPolicy
+	var err error
+	if len(nsFilter) > 0 {
+		for _, ns := range nsFilter {
+			if strings.Contains(namespace, ns) {
+				policies, err = getCrownjewelPolicy(client, cname, namespace, labels)
+				if err != nil {
+					log.Error().Msg("Error getting Crown jewel policy, err=" + err.Error())
+				}
+			}
+		}
+		systempolicy.UpdateSysPolicies(policies)
+	} else if len(nsNotFilter) > 0 {
+		for _, notns := range nsNotFilter {
+			if !strings.Contains(namespace, notns) {
+				policies, err = getCrownjewelPolicy(client, cname, namespace, labels)
+				if err != nil {
+					log.Error().Msg("Error getting Crown jewel policy, err=" + err.Error())
+				}
+			}
+		}
+		systempolicy.UpdateSysPolicies(policies)
+	}
+	return nil
+}
+
+// Generate crown jewel policy
+func getCrownjewelPolicy(client kubernetes.Interface, cname, namespace string, labels string) ([]types.KnoxSystemPolicy, error) {
+	var policies []types.KnoxSystemPolicy
+
+	var matchedMountPaths []string
+	var ms types.MatchSpec
+	action := "Allow"
+
+	// mount paths being used (from observability)
+	sumResp, fromSrc, _ := usedMountPath(client, namespace, labels)
+
+	// all mount paths being used (from k8s cluster)
+	mnt, _ := getVolumeMountPaths(client, labels)
+
+	// mount paths being used and are present in observability data (accessed mount paths)
+	matchedMountPaths, _ = accessedMountPaths(sumResp, mnt)
+
+	// process paths being used and are present in observability data
+	matchedProcessPaths, _ := getProcessList(client, namespace, labels)
+
+	policy := createCrownjewelPolicy(ms, cname, namespace, action, labels, mnt, matchedMountPaths, matchedProcessPaths, fromSrc)
+	// Check for empty policy
+	if policy.Spec.File.MatchDirectories == nil && policy.Spec.File.MatchPaths == nil &&
+		policy.Spec.Process.MatchDirectories == nil && policy.Spec.Process.MatchPaths == nil {
+		return nil, nil
+	}
+	policies = append(policies, policy)
+
+	return policies, nil
+}
+
+// Build Crown jewel System policy structure
+func buildSystemPolicy(cname, ns, action string, labels string, matchDirs []types.KnoxMatchDirectories, matchPaths []types.KnoxMatchPaths) types.KnoxSystemPolicy {
+	clustername := config.GetCfgClusterName()
+
+	// create policy name
+	name := strconv.FormatUint(uint64(common.HashInt(labels+ns+clustername+cname)), 10)
+	return types.KnoxSystemPolicy{
+		APIVersion: "security.kubearmor.com/v1",
+		Kind:       "KubeArmorPolicy",
+		Metadata: map[string]string{
+			"name":      "autopol-sensitive-" + name,
+			"namespace": ns,
+			"status":    "latest",
+		},
+		Spec: types.KnoxSystemSpec{
+			Severity: 7,
+			Selector: types.Selector{
+				MatchLabels: libs.LabelMapFromString(labels)},
+			Action:  "Allow", // global action - default Allow
+			Message: "Sensitive assets and process control policy",
+			File: types.KnoxSys{
+				MatchDirectories: matchDirs,
+			},
+			Process: types.KnoxSys{
+				MatchPaths: matchPaths,
+			},
+		},
+	}
+}
+
+func createCrownjewelPolicy(ms types.MatchSpec, cname, namespace, action string, labels string, matchedDirPts, matchedMountPts, matchedProcessPts []string, fromSrc map[string]string) types.KnoxSystemPolicy {
+	var matchDirs []types.KnoxMatchDirectories
+	i := 1
+	for _, dirpath := range matchedDirPts {
+		action = "Block"
+		// TODO: handle serviceaccount token access
+		// ignore serviceaccount token related accesses
+		if strings.Contains(dirpath, "serviceaccount") {
+			continue
+		}
+
+		for _, mountPt := range matchedMountPts {
+			if dirpath == mountPt {
+				action = "Allow"
+				break
+			}
+		}
+
+		var fromSourceVal []types.KnoxFromSource
+		for key, value := range fromSrc {
+			if strings.HasPrefix(key, dirpath) {
+				// Check if the value already exists in fromSourceVal
+				exists := false
+				for _, existing := range fromSourceVal {
+					if existing.Path == value {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					fromSourceVal = append(fromSourceVal, types.KnoxFromSource{Path: value})
+				}
+			}
+		}
+
+		matchDir := types.KnoxMatchDirectories{
+			Dir:        dirpath + "/",
+			Recursive:  true,
+			FromSource: fromSourceVal,
+			Action:     action,
+		}
+
+		if action == "Allow" {
+			// Block that dir from global access
+			matchAllowedDir := types.KnoxMatchDirectories{
+				Dir:       dirpath + "/",
+				Recursive: true,
+				Action:    "Block",
+			}
+			matchDirs = append(matchDirs, matchAllowedDir)
+		}
+
+		matchDirs = append(matchDirs, matchDir)
+
+		if i == 1 {
+			// default allow access to root directory "/"
+			matchDir := types.KnoxMatchDirectories{
+				Dir:       "/",
+				Recursive: true,
+			}
+			matchDirs = append(matchDirs, matchDir)
+			i++
+		}
+	}
+
+	var matchPaths []types.KnoxMatchPaths
+	for _, processpath := range matchedProcessPts {
+		matchPath := types.KnoxMatchPaths{
+			Path: processpath,
+		}
+		matchPaths = append(matchPaths, matchPath)
+	}
+
+	policy := buildSystemPolicy(cname, namespace, action, labels, matchDirs, matchPaths)
+
+	return policy
+}

--- a/src/libs/common.go
+++ b/src/libs/common.go
@@ -589,6 +589,7 @@ func WriteKubeArmorPolicyToYamlFile(fname string, policies []types.KubeArmorPoli
 			continue
 		}
 		writeYamlByte(f, yamlBytes)
+		f.WriteString("---\n")
 	}
 
 	if err := f.Close(); err != nil {

--- a/src/plugin/kubearmor.go
+++ b/src/plugin/kubearmor.go
@@ -71,12 +71,15 @@ func ConvertKnoxSystemPolicyToKubeArmorPolicy(knoxPolicies []types.KnoxSystemPol
 
 		kubePolicy.Spec = policy.Spec
 
-		if kubePolicy.Kind == types.KindKubeArmorPolicy && policy.Spec.Action == "Allow" {
-			dirRule := types.KnoxMatchDirectories{
-				Dir:       types.PreConfiguredKubearmorRule,
-				Recursive: true,
+		// skip adding preconfigured rule in case of crown-jewel policies
+		if !strings.Contains(policy.Metadata["name"], "sensitive") {
+			if kubePolicy.Kind == types.KindKubeArmorPolicy && policy.Spec.Action == "Allow" {
+				dirRule := types.KnoxMatchDirectories{
+					Dir:       types.PreConfiguredKubearmorRule,
+					Recursive: true,
+				}
+				kubePolicy.Spec.File.MatchDirectories = append(policy.Spec.File.MatchDirectories, dirRule)
 			}
-			kubePolicy.Spec.File.MatchDirectories = append(policy.Spec.File.MatchDirectories, dirRule)
 		}
 
 		for _, procpath := range kubePolicy.Spec.Process.MatchPaths {

--- a/src/recommendpolicy/helperFunctions.go
+++ b/src/recommendpolicy/helperFunctions.go
@@ -122,7 +122,6 @@ func getNextRule(idx *int) (types.MatchSpec, error) {
 }
 
 func genericPolicy(precondition []string) bool {
-
 	for _, preCondition := range precondition {
 		if strings.Contains(preCondition, "OPTSCAN") {
 			return true
@@ -132,7 +131,6 @@ func genericPolicy(precondition []string) bool {
 }
 
 func generateKnoxSystemPolicy(name, namespace string, labels LabelMap) ([]types.KnoxSystemPolicy, error) {
-
 	var ms types.MatchSpec
 	var err error
 	var policies []types.KnoxSystemPolicy
@@ -203,6 +201,9 @@ func generateKyvernoPolicy(name, namespace string, labels LabelMap) ([]kyvernov1
 func createRestrictAutomountSATokenPolicy(ms types.MatchSpec, name, namespace string, labels LabelMap) kyvernov1.PolicyInterface {
 	policyInterface := *(ms.KyvernoPolicy)
 	policy := (policyInterface.(*kyvernov1.Policy)).DeepCopy()
+	if policy.Annotations == nil {
+		policy.Annotations = make(map[string]string)
+	}
 	policy.Annotations[types.RecommendedPolicyTagsAnnotation] = strings.Join(ms.KyvernoPolicyTags, ",")
 	policy.Name = name + "-" + ms.Name
 	policy.Namespace = namespace
@@ -351,7 +352,6 @@ func createPolicy(ms types.MatchSpec, name, namespace string, labels LabelMap) (
 }
 
 func addPolicyRule(policy *types.KnoxSystemPolicy, r *types.KnoxSystemSpec) {
-
 	if r.File.MatchDirectories != nil || r.File.MatchPaths != nil {
 		policy.Spec.File = r.File
 	}

--- a/src/server/grpcServer.go
+++ b/src/server/grpcServer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/accuknox/auto-policy-discovery/src/crownjewel"
 	"github.com/accuknox/auto-policy-discovery/src/license"
 	"github.com/spf13/viper"
 
@@ -371,6 +372,8 @@ func AddServers(s *grpc.Server) *grpc.Server {
 	//start recommendation
 	recommend.StartRecommendWorker()
 
+	// start crown jewel
+	crownjewel.StartCrownjewelWorker()
 	return s
 }
 

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -287,7 +287,8 @@ func WriteSystemPoliciesToFile(namespace, clustername, labels, fromsource string
 	latestPolicies := libs.GetSystemPolicies(CfgDB, namespace, "latest")
 	if len(latestPolicies) > 0 {
 		kubeArmorPolicies := plugin.ConvertKnoxSystemPolicyToKubeArmorPolicy(latestPolicies)
-		libs.WriteKubeArmorPolicyToYamlFile("kubearmor_policies", kubeArmorPolicies)
+		fname := "kubearmor_policies_sensitive"
+		libs.WriteKubeArmorPolicyToYamlFile(fname, kubeArmorPolicies)
 	}
 	WriteSystemPoliciesToFile_Ext(namespace, clustername, labels, fromsource, includeNetwork)
 }

--- a/src/types/configData.go
+++ b/src/types/configData.go
@@ -130,7 +130,13 @@ type ConfigRecommendPolicy struct {
 	OneTimeJobTimeSelection            string `json:"one_time_job_time_selection,omitempty" bson:"one_time_job_time_selection,omitempty"`
 	RecommendHostPolicy                bool   `json:"recommend_host_policy,omitempty" bson:"recommend_host_policy,omitempty"`
 	RecommendAdmissionControllerPolicy bool   `json:"recommend_admission_controller_policy,omitempty" bson:"recommend_admission_controller_policy,omitempty"`
-	RecommendTemplateVersion                    string `json:"template_version,omitempty" bson:"template_version,omitempty"`
+	RecommendTemplateVersion           string `json:"template_version,omitempty" bson:"template_version,omitempty"`
+}
+
+type ConfigCrownjewelPolicy struct {
+	OperationMode           int    `json:"operation_mode,omitempty" bson:"operation_mode,omitempty"`
+	CronJobTimeInterval     string `json:"cronjob_time_interval,omitempty" bson:"cronjob_time_interval,omitempty"`
+	OneTimeJobTimeSelection string `json:"one_time_job_time_selection,omitempty" bson:"one_time_job_time_selection,omitempty"`
 }
 
 type Configuration struct {
@@ -145,12 +151,13 @@ type Configuration struct {
 	ConfigCiliumHubble   ConfigCiliumHubble   `json:"config_cilium_hubble,omitempty" bson:"config_cilium_hubble,omitempty"`
 	ConfigKubeArmorRelay ConfigKubeArmorRelay `json:"config_kubearmor_relay,omitempty" bson:"config_kubearmor_relay,omitempty"`
 
-	ConfigNetPolicy                 ConfigNetworkPolicy             `json:"config_network_policy,omitempty" bson:"config_network_policy,omitempty"`
-	ConfigSysPolicy                 ConfigSystemPolicy              `json:"config_system_policy,omitempty" bson:"config_system_policy,omitempty"`
-	ConfigAdmissionControllerPolicy ConfigAdmissionControllerPolicy `json:"config_admission_controller_policy,omitempty" bson:"config_admission_controller_policy,omitempty"`
-	ConfigClusterMgmt               ConfigClusterMgmt               `json:"config_cluster_mgmt,omitempty" bson:"config_cluster_mgmt,omitempty"`
-	ConfigObservability             ConfigObservability             `json:"config_observability,omitempty" bson:"config_observability,omitempty"`
-	ConfigPurgeOldDBEntries         ConfigPurgeOldDBEntries         `json:"config_purge_old_db_entries,omitempty" bson:"config_purge_old_db_entries,omitempty"`
-	ConfigRecommendPolicy           ConfigRecommendPolicy           `json:"config_recommend_policy,omitempty" bson:"config_recommend_policy,omitempty"`
-	ConfigAutoDepolyDiscoveredPolicy bool `json:"config_dsp,omitempty" bson:"config_dsp,omitempty"`
+	ConfigNetPolicy                  ConfigNetworkPolicy             `json:"config_network_policy,omitempty" bson:"config_network_policy,omitempty"`
+	ConfigSysPolicy                  ConfigSystemPolicy              `json:"config_system_policy,omitempty" bson:"config_system_policy,omitempty"`
+	ConfigAdmissionControllerPolicy  ConfigAdmissionControllerPolicy `json:"config_admission_controller_policy,omitempty" bson:"config_admission_controller_policy,omitempty"`
+	ConfigClusterMgmt                ConfigClusterMgmt               `json:"config_cluster_mgmt,omitempty" bson:"config_cluster_mgmt,omitempty"`
+	ConfigObservability              ConfigObservability             `json:"config_observability,omitempty" bson:"config_observability,omitempty"`
+	ConfigPurgeOldDBEntries          ConfigPurgeOldDBEntries         `json:"config_purge_old_db_entries,omitempty" bson:"config_purge_old_db_entries,omitempty"`
+	ConfigRecommendPolicy            ConfigRecommendPolicy           `json:"config_recommend_policy,omitempty" bson:"config_recommend_policy,omitempty"`
+	ConfigAutoDepolyDiscoveredPolicy bool                            `json:"config_dsp,omitempty" bson:"config_dsp,omitempty"`
+	ConfigCrownjewelPolicy           ConfigCrownjewelPolicy          `json:"config_crownjewel_policy,omitempty" bson:"config_crownjewel_policy,omitempty"`
 }

--- a/src/types/policyData.go
+++ b/src/types/policyData.go
@@ -247,6 +247,7 @@ type KnoxMatchPaths struct {
 	ReadOnly   bool             `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
 	OwnerOnly  bool             `json:"ownerOnly,omitempty" yaml:"ownerOnly,omitempty"`
 	FromSource []KnoxFromSource `json:"fromSource,omitempty" yaml:"fromSource,omitempty"`
+	Action     string           `json:"action,omitempty"`
 }
 
 // KnoxMatchDirectories Structure
@@ -256,6 +257,7 @@ type KnoxMatchDirectories struct {
 	ReadOnly   bool             `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
 	OwnerOnly  bool             `json:"ownerOnly,omitempty" yaml:"ownerOnly,omitempty"`
 	FromSource []KnoxFromSource `json:"fromSource,omitempty" yaml:"fromSource,omitempty"`
+	Action     string           `json:"action,omitempty"`
 }
 
 // KnoxMatchProtocols Structure


### PR DESCRIPTION
**Description**

Add support for generating lenient policies protecting sensitive assets (mount points here)

**Problem**
Currently we were discovering least-permissive security policies using Discovery Engine. Ideally these policies were designed to get us a Zero-trust security posture by only allowing the binaries which are essential for running any particular application. But the issue with these types of policies is that it's very difficult to actually create an exhaustive policy which contains all the necessary binaries allowed. If we miss even a single important binary, that would have caused the whole application to crash in worst case.

**Solution**
The aim of this PR is to identify the crown-jewels or the list of important assets which when protected can give us a fairly good security posture for the whole application. 

**PR changes**
This PR identifies the paths mounted by any application and check if they are actually being used. We then create a "Crown-jewel" lenient policy which only allows the access of the particular mount paths by a particular binary based on the actual usage and deny access from others.

Example of a Crown jewel policy:
```
 - apiVersion: v1
  kind: KubeArmorPolicy
  metadata:
    name: autopol-assets-vault
    namespace: default
  spec:
    action: Allow
    file:
      matchDirectories:
      - action: Block
        dir: /vault/data/
        recursive: true
      - dir: /vault/data/
        fromSource:
        - path: /bin/vault
        recursive: true
      - dir: /
        recursive: true
      - dir: /vault/config/
        recursive: true
      - action: Block
        dir: /home/vault/
        recursive: true
      - dir: /home/vault/
        fromSource:
        - path: /bin/sh
        recursive: true
    message: Sensitive assets and process control policy
    network: {}
    process:
      matchPaths:
      - path: /bin/sh
      - path: /bin/vault
      - path: /bin/busybox
    selector:
      matchLabels:
        app.kubernetes.io/instance: vault
        app.kubernetes.io/name: vault
        component: server
        helm.sh/chart: vault-0.24.1
    severity: 7
```

Here in the above policy, access to the dir:  `/home/vault/` is only allowed by `/bin/sh` and `/vault/data/` by `/bin/vault`.  The other mount path `/vault/config/` is not being used, so it's set to `Block`. As Vault is using Alpine image, that's why we see the process `/bin/busybox` being used (will be a symlink to system packages).

ref: https://github.com/accuknox/discovery-engine/issues/715