### PR TITLE
updated processing of logs to get summary for unorchestrated workloads

### DIFF
--- a/src/observability/kubearmor.go
+++ b/src/observability/kubearmor.go
@@ -110,7 +110,6 @@ func ProcessSystemLogs() {
 
 			if locLog.Type == "ContainerLog" && locLog.NamespaceName == types.PolicyDiscoveryContainerNamespace {
 				locLog.NamespaceName = types.PolicyDiscoveryContainerNamespace
-				locLog.PodName = types.PolicyDiscoveryContainerPodName
 			}
 
 			if locLog.Type == "HostLog" || locLog.Type == "MatchedHostPolicy" {

--- a/src/observability/summarizer.go
+++ b/src/observability/summarizer.go
@@ -167,7 +167,6 @@ func convertSysLogToSysSummaryMap(syslogs []*pb.Alert) {
 
 		if syslog.Type == "ContainerLog" && syslog.NamespaceName == types.PolicyDiscoveryContainerNamespace {
 			sysSummary.NamespaceName = types.PolicyDiscoveryContainerNamespace
-			sysSummary.PodName = types.PolicyDiscoveryContainerPodName
 		}
 
 		if syslog.Type == "HostLog" || syslog.Type == "MatchedHostPolicy" {


### PR DESCRIPTION
If there are multiple containerized deployments in unorchestrated workloads then we get summary for all containerized deployments in a single table under podname: `container_podname`.
For example: Below summary table have process and file data for 2 different containerized workloads i.e. firewall & verifier.
These needs to be seprate under their own podname.
```  
  Pod Name        container_podname    
  Namespace Name  container_namespace  
  Cluster Name                         
  Container Name  admiring_chebyshev   
  Labels                               

Process Data
+----------------------------------+-------------------------------+-------+------------------------------+--------+
|           SRC PROCESS            |   DESTINATION PROCESS PATH    | COUNT |      LAST UPDATED TIME       | STATUS |
+----------------------------------+-------------------------------+-------+------------------------------+--------+
| /usr/bin/containerd-shim-runc-v2 | /home/sediment/build/firewall | 1     | Mon Jun  5 11:00:07 UTC 2023 | Allow  |
| /usr/bin/containerd-shim-runc-v2 | /home/sediment/build/verifier | 1     | Mon Jun  5 11:01:29 UTC 2023 | Allow  |
+----------------------------------+-------------------------------+-------+------------------------------+--------+


File Data
+-------------------------------+----------------------------------------------------------------------------------------------------------------------+-------+------------------------------+--------+
|          SRC PROCESS          |                                                DESTINATION FILE PATH                                                 | COUNT |      LAST UPDATED TIME       | STATUS |
+-------------------------------+----------------------------------------------------------------------------------------------------------------------+-------+------------------------------+--------+
| /home/sediment/build/firewall | /etc/group                                                                                                           | 2     | Mon Jun  5 11:00:07 UTC 2023 | Allow  |
| /home/sediment/build/firewall | /etc/ld.so.cache                                                                                                     | 1     | Mon Jun  5 11:00:07 UTC 2023 | Allow  |
| /home/sediment/build/firewall | /var/lib/docker/overlay2/0272f0415529a9e2346cb5443795feaabd596c69b824fc62196c1c9faf56253d/merged/sys                 | 2     | Mon Jun  5 11:00:07 UTC 2023 | Allow  |
| /home/sediment/build/firewall | /var/lib/docker/overlay2/0272f0415529a9e2346cb5443795feaabd596c69b824fc62196c1c9faf56253d/merged/sys/fs/cgroup       | 1     | Mon Jun  5 11:00:07 UTC 2023 | Allow  |
| /home/sediment/build/verifier | /                                                                                                                    | 2     | Mon Jun  5 11:01:29 UTC 2023 | Allow  |
| /home/sediment/build/verifier | /dev/console                                                                                                         | 1     | Mon Jun  5 11:01:29 UTC 2023 | Allow  |
```