### PR TITLE
[fix](template-version) Adding ability to specify policy-template version

### DIFF
--- a/src/conf/local-file.yaml
+++ b/src/conf/local-file.yaml
@@ -119,6 +119,7 @@ recommend:
   operation-mode: 1                       # 1: cronjob | 2: one-time-job
   cron-job-time-interval: "1h0m00s"       # format: XhYmZs
   recommend-host-policy: true
+  template-version: "v0.2.2"              # policy template version to be used for recommendation (keep empty to fetches latest)
 
 # license
 license:

--- a/src/conf/local.yaml
+++ b/src/conf/local.yaml
@@ -83,6 +83,7 @@ recommend:
   operation-mode: 1                       # 1: cronjob | 2: one-time-job
   cron-job-time-interval: "1h0m00s"       # format: XhYmZs
   recommend-host-policy: true
+  template-version: "v0.2.1"
 
 # license
 license:

--- a/src/config/configManager.go
+++ b/src/config/configManager.go
@@ -216,6 +216,7 @@ func LoadConfigFromFile() {
 		OperationMode:                      viper.GetInt("recommend.operation-mode"),
 		RecommendHostPolicy:                viper.GetBool("recommend.host-policy"),
 		RecommendAdmissionControllerPolicy: viper.GetBool("recommend.admission-controller-policy"),
+		RecommendTemplateVersion:           viper.GetString("recommend.template-version"),
 	}
 
 	// load database
@@ -527,4 +528,8 @@ func GetCfgRecommendHostPolicy() bool {
 
 func GetCfgRecommendAdmissionControllerPolicy() bool {
 	return CurrentCfg.ConfigRecommendPolicy.RecommendAdmissionControllerPolicy
+}
+
+func GetCfgRecommendTemplateVersion() string {
+	return CurrentCfg.ConfigRecommendPolicy.RecommendTemplateVersion
 }

--- a/src/libs/common.go
+++ b/src/libs/common.go
@@ -150,11 +150,13 @@ func SetDefaultConfig() {
 	viper.SetDefault("feed-consumer.pulsar.operation-timeout", "30")
 
 	// recommend config
-
 	viper.SetDefault("recommend.cron-job-time-interval", "1h0m00s")
 	viper.SetDefault("recommend.operation-mode", 1)
 	viper.SetDefault("recommend.host-policy", true)
 	viper.SetDefault("recommend.admission-controller-policy", true)
+	viper.SetDefault("recommend.template-version", "")
+
+	// DE license config
 	viper.SetDefault("license.enabled", false)
 
 	// pprof

--- a/src/recommendpolicy/recommendPolicy.go
+++ b/src/recommendpolicy/recommendPolicy.go
@@ -44,8 +44,11 @@ const (
 // CurrentVersion stores the current version of policy-template
 var CurrentVersion string
 
-// LatestVersion stores the latest version of policy-template
+// LatestVersion stores the Latest version of policy-template
 var LatestVersion string
+
+// Version stores the version of policy-template to be downloaded
+var Version string
 
 // LabelMap is an alias for map[string]string
 type LabelMap = map[string]string
@@ -124,6 +127,8 @@ func StopRecommendCronJob() {
 func RecommendPolicyMain() {
 
 	nsNotFilter := cfg.CurrentCfg.ConfigSysPolicy.NsNotFilter
+	Version = cfg.GetCfgRecommendTemplateVersion()
+
 	client := cluster.ConnectK8sClient()
 	if client == nil {
 		return
@@ -237,13 +242,16 @@ func GetHardenPolicy(deployments *v1.DeploymentList, replicaSets *v1.ReplicaSetL
 
 	var policies []types.KnoxSystemPolicy
 	if !isLatest() {
-		version, err := DownloadAndUnzipRelease()
+		err := DownloadAndUnzipRelease(Version)
 		if err != nil {
-			log.Error().Msgf("Unable to download %v", err.Error())
+			log.Error().Msgf("Unable to download template %v", err.Error())
 			return nil
 		}
-		log.Info().Msgf("Downloaded version: %v", version)
+		log.Info().Msgf("Downloaded policy template version: %v", LatestVersion)
+	} else {
+		log.Info().Msgf("Using cached template version: %v", CurrentVersion)
 	}
+
 	for _, d := range deployments.Items {
 		deploy := uniqueNsDeploy(d.Name, d.Namespace)
 

--- a/src/types/configData.go
+++ b/src/types/configData.go
@@ -130,6 +130,7 @@ type ConfigRecommendPolicy struct {
 	OneTimeJobTimeSelection            string `json:"one_time_job_time_selection,omitempty" bson:"one_time_job_time_selection,omitempty"`
 	RecommendHostPolicy                bool   `json:"recommend_host_policy,omitempty" bson:"recommend_host_policy,omitempty"`
 	RecommendAdmissionControllerPolicy bool   `json:"recommend_admission_controller_policy,omitempty" bson:"recommend_admission_controller_policy,omitempty"`
+	RecommendTemplateVersion                    string `json:"template_version,omitempty" bson:"template_version,omitempty"`
 }
 
 type Configuration struct {


### PR DESCRIPTION
This PR contains the following changes 

- Updated policy template download logic to get a specific version of PT or the latest based on config flag
- Use existing cache if a specific version is specified using the config file

**Purpose of PR?**:

The discovery engine's recommendation feature heavily relies on the policy-template release branch. If there is an update on the policy template release older/stable versions of Discovery Engine might break. To avoid this we are introducing the ability to specify the version of the policy template release to be used in the Discovery Engine

Fixes #

**Does this PR introduce a breaking change?** No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- added policy-template version 'v0.2.2' to the config file
- omitted policy-template version to check if new policy-template releases are getting downloaded 

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->