### PR TITLE
Remove container name from hash for system policy and remove controller uid from labels for jobs

### DIFF
--- a/src/cluster/k8sClientHandler.go
+++ b/src/cluster/k8sClientHandler.go
@@ -164,7 +164,8 @@ func GetNamespacesFromK8sClient() []string {
 var skipLabelKey = []string{
 	"pod-template-hash",                  // common k8s hash label
 	"controller-revision-hash",           // from istana robot-shop
-	"statefulset.kubernetes.io/pod-name"} // from istana robot-shop
+	"statefulset.kubernetes.io/pod-name", // from istana robot-shop
+	"controller-uid"}                     // from jobs
 
 func GetPodsFromK8sClient() []types.Pod {
 	results := []types.Pod{}

--- a/src/cluster/k8sClientHandler.go
+++ b/src/cluster/k8sClientHandler.go
@@ -165,7 +165,7 @@ var skipLabelKey = []string{
 	"pod-template-hash",                  // common k8s hash label
 	"controller-revision-hash",           // from istana robot-shop
 	"statefulset.kubernetes.io/pod-name", // from istana robot-shop
-	"controller-uid"}                     // from jobs
+	types.JobLabelControllerUidStr}       // from jobs
 
 func GetPodsFromK8sClient() []types.Pod {
 	results := []types.Pod{}

--- a/src/cluster/k8sClientHandler.go
+++ b/src/cluster/k8sClientHandler.go
@@ -165,7 +165,7 @@ var skipLabelKey = []string{
 	"pod-template-hash",                  // common k8s hash label
 	"controller-revision-hash",           // from istana robot-shop
 	"statefulset.kubernetes.io/pod-name", // from istana robot-shop
-	types.JobLabelControllerUidStr}       // from jobs
+	types.LabelJobControllerUid}          // from jobs
 
 func GetPodsFromK8sClient() []types.Pod {
 	results := []types.Pod{}

--- a/src/libs/common.go
+++ b/src/libs/common.go
@@ -724,3 +724,16 @@ func HashSystemSummary(summary *types.SystemSummary) string {
 	)
 	return hex.EncodeToString(h.Sum(nil))
 }
+
+// Removes the label associated to the key specified and returns the final label
+func RemoveFieldFromLabel(srcLabel, keyLabel string) string {
+	labels := strings.Split(srcLabel, ",")
+	resLabels := []string{}
+	for _, label := range labels {
+		if strings.HasPrefix(label, keyLabel) {
+			continue
+		}
+		resLabels = append(resLabels, label)
+	}
+	return strings.Join(resLabels, ",")
+}

--- a/src/plugin/kubearmor.go
+++ b/src/plugin/kubearmor.go
@@ -467,9 +467,7 @@ func StartKubeArmorRelay(StopChan chan struct{}, cfg types.ConfigKubeArmorRelay)
 					Owner:             &owner,
 				}
 
-				if strings.Contains(kubearmorLog.Labels, types.JobLabelControllerUidStr) {
-					kubearmorLog.Labels = libs.RemoveFieldFromLabel(kubearmorLog.Labels, types.JobLabelControllerUidStr)
-				}
+				kubearmorLog.Labels = libs.RemoveFieldFromLabel(kubearmorLog.Labels, types.LabelJobControllerUid)
 
 				KubeArmorRelayLogsMutex.Lock()
 				KubeArmorRelayLogs = append(KubeArmorRelayLogs, &kubearmorLog)
@@ -526,9 +524,7 @@ func StartKubeArmorRelay(StopChan chan struct{}, cfg types.ConfigKubeArmorRelay)
 					continue
 				}
 
-				if strings.Contains(res.Labels, types.JobLabelControllerUidStr) {
-					res.Labels = libs.RemoveFieldFromLabel(res.Labels, types.JobLabelControllerUidStr)
-				}
+				res.Labels = libs.RemoveFieldFromLabel(res.Labels, types.LabelJobControllerUid)
 
 				KubeArmorRelayLogsMutex.Lock()
 				KubeArmorRelayLogs = append(KubeArmorRelayLogs, res)

--- a/src/plugin/kubearmor.go
+++ b/src/plugin/kubearmor.go
@@ -467,6 +467,10 @@ func StartKubeArmorRelay(StopChan chan struct{}, cfg types.ConfigKubeArmorRelay)
 					Owner:             &owner,
 				}
 
+				if strings.Contains(kubearmorLog.Labels, types.JobLabelControllerUidStr) {
+					kubearmorLog.Labels = libs.RemoveFieldFromLabel(kubearmorLog.Labels, types.JobLabelControllerUidStr)
+				}
+
 				KubeArmorRelayLogsMutex.Lock()
 				KubeArmorRelayLogs = append(KubeArmorRelayLogs, &kubearmorLog)
 				KubeArmorRelayLogsMutex.Unlock()
@@ -520,6 +524,10 @@ func StartKubeArmorRelay(StopChan chan struct{}, cfg types.ConfigKubeArmorRelay)
 
 				if len(res.Resource) != 0 && res.Operation != "Network" && !strings.HasPrefix(res.Resource, "/") {
 					continue
+				}
+
+				if strings.Contains(res.Labels, types.JobLabelControllerUidStr) {
+					res.Labels = libs.RemoveFieldFromLabel(res.Labels, types.JobLabelControllerUidStr)
 				}
 
 				KubeArmorRelayLogsMutex.Lock()

--- a/src/systempolicy/systemPolicy.go
+++ b/src/systempolicy/systemPolicy.go
@@ -772,8 +772,7 @@ func mergeSysPolicies(pols []types.KnoxSystemPolicy) []types.KnoxSystemPolicy {
 	var results []types.KnoxSystemPolicy
 	for _, pol := range pols {
 		pol.Metadata["name"] = "autopol-system-" +
-			strconv.FormatUint(uint64(common.HashInt(pol.Metadata["labels"]+
-				pol.Metadata["namespace"]+pol.Metadata["clustername"]+pol.Metadata["containername"])), 10)
+			strconv.FormatUint(uint64(common.HashInt(pol.Metadata["labels"]+pol.Metadata["namespace"]+pol.Metadata["clustername"])), 10)
 		i := checkIfMetadataMatches(pol, results)
 		if i < 0 {
 			results = append(results, pol)

--- a/src/types/constants.go
+++ b/src/types/constants.go
@@ -64,5 +64,5 @@ const (
 
 	// For Jobs, this field from labels changes everytime
 	// Hence ignoring the same from labels if exist
-	JobLabelControllerUidStr = "controller-uid"
+	LabelJobControllerUid = "controller-uid"
 )

--- a/src/types/constants.go
+++ b/src/types/constants.go
@@ -61,4 +61,8 @@ const (
 	// RecommendedPolicyDescriptionAnnotation is the annotation used to store the description of the recommended policy.
 	// This annotation is used to identify the description associated with a policy by kubearmor-client.
 	RecommendedPolicyDescriptionAnnotation = "policies.kyverno.io/description"
+
+	// For Jobs, this field from labels changes everytime
+	// Hence ignoring the same from labels if exist
+	JobLabelControllerUidStr = "controller-uid"
 )


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #
https://accu-knox.atlassian.net/browse/CNAPP-5995
https://accu-knox.atlassian.net/browse/CNAPP-5996

**Does this PR introduce a breaking change?** No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Verified by using kubetls and some sample deployments like sock-shop, wordpress-mysql and google microservices

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->