### PR TITLE
fix(observability): fix deadlocks and concurrent write issue [WIP]

### DIFF
--- a/src/observability/observability.go
+++ b/src/observability/observability.go
@@ -144,8 +144,8 @@ func GetDeployNames(request *opb.Request) (opb.DeployNameResponse, error) {
 	return opb.DeployNameResponse{DeployName: result}, nil
 }
 
-func UpsertSummaryCronJob(tempSummarizerMap map[types.SystemSummary]types.SysSummaryTimeCount, wg *sync.WaitGroup) {
-	defer wg.Done()
+func UpsertSummaryCronJob(tempSummarizerMap map[types.SystemSummary]types.SysSummaryTimeCount) {
+	//defer wg.Done()
 	// update summary map to DB
 	if err := libs.UpsertSystemSummary(CfgDB, tempSummarizerMap); err != nil {
 		log.Error().Msg(err.Error())

--- a/src/observability/publisher.go
+++ b/src/observability/publisher.go
@@ -1,8 +1,6 @@
 package observability
 
 import (
-	"sync"
-
 	"github.com/accuknox/auto-policy-discovery/src/common"
 	cfg "github.com/accuknox/auto-policy-discovery/src/config"
 	"github.com/accuknox/auto-policy-discovery/src/types"
@@ -18,11 +16,11 @@ func ProcessSystemSummary() {
 	tempSummarizerMap := common.MoveMap(SummarizerMap)
 	SummarizerMapMutex.Unlock()
 
-	var ProcessSystemSummaryWg sync.WaitGroup
+	//var ProcessSystemSummaryWg sync.WaitGroup
 
 	if cfg.GetCfgObservabilityWriteToDB() {
-		ProcessSystemSummaryWg.Add(1)
-		go UpsertSummaryCronJob(tempSummarizerMap, &ProcessSystemSummaryWg)
+		//ProcessSystemSummaryWg.Add(1)
+		UpsertSummaryCronJob(tempSummarizerMap)
 	}
 
 	if cfg.GetCfgPublisherEnable() {
@@ -43,5 +41,5 @@ func ProcessSystemSummary() {
 		}
 		PublisherMutex.Unlock()
 	}
-	ProcessSystemSummaryWg.Wait()
+	//ProcessSystemSummaryWg.Wait()
 }


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #

- Since go routines were used over here and shared map was being passed to the function due to which deadlocks was getting created and map value was being overwritten by other go routine. We should either use lock or channel to pass data.

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Bug fix. Fixes #<issue number>
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->