### PR TITLE
feat(observability): Aggregate summary data before publishing to stream

### DIFF
--- a/src/observability/publisher.go
+++ b/src/observability/publisher.go
@@ -1,7 +1,9 @@
 package observability
 
 import (
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/accuknox/auto-policy-discovery/src/common"
 	cfg "github.com/accuknox/auto-policy-discovery/src/config"
@@ -27,8 +29,15 @@ func ProcessSystemSummary() {
 
 	if cfg.GetCfgPublisherEnable() {
 		PublisherMutex.Lock()
+		timeVar := time.Now()
+		tempSummarizerMap = getAggregatedSummaryMap(tempSummarizerMap)
+
+		log.Info().Msgf("Events to publish after aggregation: [%v]", len(tempSummarizerMap))
+		count := 0
+
 		// publish summary map in GRPC
 		for ss, sstc := range tempSummarizerMap {
+			count++
 			var locSummary types.SystemSummary = ss
 
 			// update count/time
@@ -41,7 +50,51 @@ func ProcessSystemSummary() {
 			// clear each published entry from data map
 			delete(tempSummarizerMap, ss)
 		}
+		log.Info().Msgf("Published %v events in %v", count, time.Since(timeVar))
 		PublisherMutex.Unlock()
 	}
 	ProcessSystemSummaryWg.Wait()
+}
+
+func getAggregatedSummaryMap(tempSummarizerMap map[types.SystemSummary]types.SysSummaryTimeCount) map[types.SystemSummary]types.SysSummaryTimeCount {
+
+	var fileArr []string
+	log.Info().Msgf("Events before aggregation: [%v]", len(tempSummarizerMap))
+
+	fileSumMap := make(map[types.SystemSummary]types.SysSummaryTimeCount)
+	updatedSummarizerMap := make(map[types.SystemSummary]types.SysSummaryTimeCount)
+	for tss, tsstc := range tempSummarizerMap {
+		if tss.Operation == types.FileOperation {
+			fileArr = append(fileArr, tss.Destination)
+			fileSumMap[tss] = tsstc
+		} else {
+			updatedSummarizerMap[tss] = tsstc
+		}
+	}
+	tempSummarizerMap = updatedSummarizerMap
+
+	aggregatedFilePaths := common.AggregatePaths(fileArr)
+
+	log.Info().Msgf("Aggregated file paths: [%v]", len(aggregatedFilePaths))
+	for ss, sstc := range fileSumMap {
+		for _, path := range aggregatedFilePaths {
+			if strings.HasPrefix(ss.Destination, path.Path) && (len(ss.Destination) == len(path.Path) || ss.Destination[len(strings.TrimSuffix(path.Path, "/"))] == '/') {
+				ss.Destination = path.Path
+				break
+			}
+		}
+
+		if existingSstc, ok := tempSummarizerMap[ss]; ok {
+			existingSstc.Count += sstc.Count
+			if sstc.UpdatedTime > existingSstc.UpdatedTime {
+				existingSstc.UpdatedTime = sstc.UpdatedTime
+			}
+			tempSummarizerMap[ss] = existingSstc
+		} else {
+			tempSummarizerMap[ss] = sstc
+		}
+
+	}
+
+	return tempSummarizerMap
 }

--- a/src/types/constants.go
+++ b/src/types/constants.go
@@ -65,4 +65,9 @@ const (
 	// For Jobs, this field from labels changes everytime
 	// Hence ignoring the same from labels if exist
 	LabelJobControllerUid = "controller-uid"
+
+	// Constants to match with operations when aggregating summary data
+	FileOperation = "File"
+	NetworkOperation = "Network"
+	ProcessOperation = "Process"
 )


### PR DESCRIPTION
**Purpose of PR?**:

The summary observability publishes all events without aggregating. This leads to a huge number of messages getting published in the stream. This PR reduces the number of summary information being published to the stream by aggregating the destination path and reducing the data by replacing the destination with the aggregated path and updating the count and ipdated_time.

Fixes _**JIRA CNAPP-6011**_

**Does this PR introduce a breaking change?** 
_**NO**_

**Checklist:**
- [x] New feature (non-breaking change which adds functionality)
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests

<!--

The PR title message must follow convention:
`<type>(<scope>): <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
    - feature(`monitor`,`enforcer`)
    - test(`tests`, `bdd`)
    - chore(`build`)
- `subject` is a single line brief description of the changes made in the pull request.

-->