### PR TITLE
fix(hardening): Download policy-template zip

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/accuknox/auto-policy-discovery/pkg/discoveredpolicy v0.0.0-20230623101739-bc5c3d9a3892
 	github.com/accuknox/auto-policy-discovery/src/protobuf v0.0.0-20230628192822-7249456fae5c
 	github.com/apache/pulsar-client-go v0.10.0
-	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/cilium/cilium v1.13.1
 	github.com/clarketm/json v1.17.1
 	github.com/confluentinc/confluent-kafka-go v1.9.2

--- a/src/go.sum
+++ b/src/go.sum
@@ -320,8 +320,6 @@ github.com/bytecodealliance/wasmtime-go v0.27.0 h1:b/mvyw1YJSwF5zNxqLH9V24ENkZGA
 github.com/bytecodealliance/wasmtime-go v0.27.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 h1:3uZCA/BLTIu+DqCfguByNMJa2HVHpXvjfy0Dy7g6fuA=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/cavaliergopher/grab/v3 v3.0.1 h1:4z7TkBfmPjmLAAmkkAZNX/6QJ1nNFdv3SdIHXju0Fr4=
-github.com/cavaliergopher/grab/v3 v3.0.1/go.mod h1:1U/KNnD+Ft6JJiYoYBAimKH2XrYptb8Kl3DFGmsjpq4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=


### PR DESCRIPTION
**Issue:** grab.Get throws error 403 Forbidden while downloading the zip file

**Fix:** Removed the grab package dependency and used net/http for downloading the policy-template zip file.

**Ticket:** https://accu-knox.atlassian.net/browse/CNAPP-7814