### PR TITLE
Fix(hardening)| Download policy-template zip

### DIFF
--- a/src/recommendpolicy/downloadTemplates.go
+++ b/src/recommendpolicy/downloadTemplates.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -101,6 +102,11 @@ func downloadZip(url string, destination string) error {
 	}
 
 	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
**Issue:** After downloading the policy template zip, it is not copied to the destination file.

**Fix:** Added copy function to copy downloaded policy-template zip to the destination file.
